### PR TITLE
Add cross-chain, cross-token, and gasless payments with Glide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ NEXT_PUBLIC_SUPABASE_URL = ''
 NEXT_PUBLIC_SUPABASE_ANON_KEY = ''
 NEXT_PUBLIC_NEYNAR_API_KEY = ''
 NEXT_PUBLIC_ALCHEMY_API_KEY = ''
+NEXT_PUBLIC_GLIDE_PROJECT_ID = ''
 
 # The following are required for tracking
 # and deployment purposes. They are also sensitive

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@mod-protocol/react-ui-shadcn": "^0.3.1",
     "@neynar/nodejs-sdk": "^1.9.6",
     "@noble/ed25519": "^2.0.0",
+    "@paywithglide/glide-js": "^0.4.0",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-aspect-ratio": "^1.0.3",

--- a/src/common/helpers/glide.ts
+++ b/src/common/helpers/glide.ts
@@ -1,0 +1,7 @@
+import { createGlideClient } from "@paywithglide/glide-js";
+import { mainnet, base, optimism, polygon, arbitrum } from "@wagmi/core/chains";
+
+export const glideClient = createGlideClient({
+  projectId: process.env.NEXT_PUBLIC_GLIDE_PROJECT_ID || "",
+  chains: [optimism, mainnet, base, arbitrum, polygon],
+});

--- a/src/common/helpers/rainbowkit.tsx
+++ b/src/common/helpers/rainbowkit.tsx
@@ -1,6 +1,6 @@
 import "@rainbow-me/rainbowkit/styles.css";
 import { getDefaultConfig, midnightTheme } from "@rainbow-me/rainbowkit";
-import { optimism, mainnet } from "@wagmi/core/chains";
+import { optimism, mainnet, base, arbitrum, polygon } from "@wagmi/core/chains";
 import { http, createConfig } from "@wagmi/core";
 import { createPublicClient } from "viem";
 
@@ -28,7 +28,7 @@ export const publicClient = createPublicClient({
 export const config = getDefaultConfig({
   appName: "herocast",
   projectId: "b34f1019e33e832831871e41741f13fc",
-  chains: [optimism],
+  chains: [optimism, mainnet, base, arbitrum, polygon],
 });
 
 export const rainbowKitTheme = midnightTheme({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,6 +1213,13 @@
     "@parcel/watcher-win32-ia32" "2.4.1"
     "@parcel/watcher-win32-x64" "2.4.1"
 
+"@paywithglide/glide-js@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@paywithglide/glide-js/-/glide-js-0.4.0.tgz#71c90d27d6bee94f210b36b7a39fa3e6215eb9a3"
+  integrity sha512-MR6noRFGmrh0Fty/j9zssmWuuvObt8KXyr57KVMDd9CXcOJtTLtDrsc2vsDaytbbjQCn7lDMx5cMyFS72aS6oQ==
+  dependencies:
+    viem "^2.9.6"
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -8715,16 +8722,7 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8814,14 +8812,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9537,6 +9528,20 @@ viem@^1.0.0, viem@^1.1.4, viem@^1.12.2, viem@^1.19.9:
     isows "1.0.3"
     ws "8.13.0"
 
+viem@^2.9.6:
+  version "2.9.26"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.9.26.tgz#def3f0c1d12e966c812f2b7fd334d9f259d88032"
+  integrity sha512-WWYsZfxDsvVsbQF9v3i0M7A2TYTtQl+pwiF5UP8/5dr15XEMGB0MJDhH3esU7jJnBd/JMjkJH/DQRAKuqYS23Q==
+  dependencies:
+    "@adraffy/ens-normalize" "1.10.0"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@scure/bip32" "1.3.2"
+    "@scure/bip39" "1.2.1"
+    abitype "1.0.0"
+    isows "1.0.3"
+    ws "8.13.0"
+
 void-elements@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
@@ -9678,7 +9683,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9691,15 +9696,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
**Overview**
This PR adds the ability to let users create a farcaster account and pay the transaction/platform fee using any of these [tokens & chains](https://docs.paywithglide.xyz/resources/supported-chains-and-tokens).

Currently, users must hold ETH on Optimism to be able to create a farcaster account. Many users have not on-ramped to Optimism and hold tokens on other chains. Glide lets users use tokens on other chains to pay for transactions on Optimism.

Additionally, users choosing to pay with ERC-20 tokens such as USDC can pay without holding/paying any gas.

**Todo**
[x] Install `@paywithglide/glide-js`
[x] Create glide client
[x] Replace wagmi's `writeContract` with Glide's `writeContract`
[x] Update copy / error checks
[ ] Test end-to-end flow