### PR TITLE
#244 add compose new draft via link

### DIFF
--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -7,14 +7,26 @@ import { PlusCircleIcon, TrashIcon } from "@heroicons/react/24/outline";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import HotkeyTooltipWrapper from "../../src/common/components/HotkeyTooltipWrapper";
 import { Button } from "../../src/components/ui/button";
+import { useRouter } from "next/router";
 
 export default function NewPost() {
   const [showToast, setShowToast] = useState(false);
 
   const { addNewPostDraft, removeAllPostDrafts } = useNewPostStore();
   const { drafts } = useNewPostStore();
+  const router = useRouter();
 
   useEffect(() => {
+    let text = router?.query?.text;
+    if (text) {
+      if (typeof text !== 'string') {
+        text = text.find(t => t) ;
+      }
+      if (text) {
+        addNewPostDraft({ text });
+        return;
+      }
+    }
     if (drafts.length === 0) {
       addNewPostDraft({});
     }


### PR DESCRIPTION
# WARNING: This is *UNTESTED* do not merge without verifying first.

## Issue Link
https://github.com/hellno/herocast/issues/244

## Considerations
There are some considerations here:
1. If someone continuously clicks a `/post?text=Blah` link they will start building up a giant list of drafts. No way to capture the added draft from the addNewPostDraft function, but if you could maybe the way to go would be delete it when route changes off the page?
2. Alternatively add a "delete all drafts" button on the drafts page if it's not already there.
3. The warpcast.com/~/compose spec has both ?text= and ?embeds[]=. There's no straight forward embeds object in the draft so I just left it. 
4. There is however a way of prompting someone to compose a cast about another cast, e.g. https://warpcast.com/~/compose?embeds[]=https://warpcast.com/semicolon.eth/0xdefdf74c then it auto quote tweets it. There is a `parentCastId` in the draft that we could fill here if a quote tweet link is detected