### PR TITLE
Add Glide development project ID

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_VERCEL_ENV = development
 NEXT_PUBLIC_URL = 'http://localhost:3000'
+NEXT_PUBLIC_GLIDE_PROJECT_ID = 'dd213fe0-563e-4acf-816c-69c4c10af0e5'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,14 +43,6 @@ cp .env.example .env.development.local
 xcopy .env.example .env.development.local
 ```
 5. Getting your ENV variables set
- 
- ### Glide API Key
- Go to [Glide's website](https://paywithglide.xyz/) and sign up with your email.
-
- They will respond shortly with an API key (it appears to be manually done).
-
- They will want to know which contracts to enable for the API key, just let them know you are with `herocast` and that they should
- already be whitelisted.
 
  ### Neynar API KEY
  Go to [Neynar's Dev Portal](https://dev.neynar.com/) and signup for the cheapest plan.


### PR DESCRIPTION
To make onboarding easier, we can let developers use a test Glide Project ID. It has been configured in the `.env.development` such that it will be automatically picked up.