### PR TITLE
Improve the guide in the CONTRIBUTING.md for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,20 +7,23 @@ Thank you for considering contributing to herocast. We welcome any contributions
 ### Dev Setup
 
 1. Clone the repo:
-  ```bash
-  git clone https://github.com/hellno/herocast.git
-  ```
+
+```bash
+git clone https://github.com/hellno/herocast.git
+```
 
 2. Install Supabase CLI:
-  - For Linux or macOS with Homebrew installed:
+
+-   For Linux or macOS with Homebrew installed:
     ```bash
     brew install supabase/tap/supabase
     ```
-  - For other platforms, download the .deb/.apk/.rpm from [here](https://github.com/supabase/cli/releases) and install it.
+-   For other platforms, download the .deb/.apk/.rpm from [here](https://github.com/supabase/cli/releases) and install it.
 
 3. Install dependencies:
-  - Install NVM (Node Version Manager) by following the instructions [here](https://github.com/nvm-sh/nvm#installing-and-updating).
-  - Switch to the appropriate Node version:
+
+-   Install NVM (Node Version Manager) by following the instructions [here](https://github.com/nvm-sh/nvm#installing-and-updating).
+-   Switch to the appropriate Node version:
     ```bash
     nvm use
     ```
@@ -28,98 +31,115 @@ Thank you for considering contributing to herocast. We welcome any contributions
     ```bash
     nvm install
     ```
-  - Install Yarn (if not already installed for this Node version):
+-   Install Yarn (if not already installed for this Node version):
     ```bash
     npm -g install yarn
     ```
-  - Install packages:
+-   Install packages:
     ```bash
     yarn
     ```
 
 4. Create a file `.env.development.local`:
-  - For macOS or Linux:
+
+-   For macOS or Linux:
     ```bash
     cp .env.example .env.development.local
     ```
-  - For Windows:
+-   For Windows:
     ```bash
     xcopy .env.example .env.development.local
     ```
 
 5. Set up your environment variables:
 
-  #### Neynar API KEY
-  - Go to [Neynar's Dev Portal](https://dev.neynar.com/) and sign up for the cheapest plan.
-  - Once you have access to the dashboard, copy the API Key from the main page at the top.
+#### Neynar API KEY
+
+-   Go to [Neynar's Dev Portal](https://dev.neynar.com/) and sign up for the cheapest plan.
+-   Once you have access to the dashboard, copy the API Key from the main page at the top.
     ```bash
     NEXT_PUBLIC_NEYNAR_API_KEY = 'neynar-api-key-here'
     ```
 
-  #### Alchemy API Key
-  - Go to [Alchemy's website](https://alchemy.com) and get your API Key.
-  - Create a new account and select the "Free" option.
-  - Select the "Optimism" chain and fill out the necessary information.
-  - In the "Apps" section, find your Optimism App and click the "API Key" button.
-  - Copy the API Key to your `.env.development.local`.
+#### Alchemy API Key
+
+-   Go to [Alchemy's website](https://alchemy.com) and get your API Key.
+-   Create a new account and select the "Free" option.
+-   Select the "Optimism" chain and fill out the necessary information.
+-   In the "Apps" section, find your Optimism App and click the "API Key" button.
+-   Copy the API Key to your `.env.development.local`.
     ```bash
     NEXT_PUBLIC_ALCHEMY_API_KEY = 'alchemy-api-key-here'
     ```
 
-  #### Farcaster account information
-  - Get a dev account for Farcaster and save your main account's mnemonic phrase.
-  - To find the mnemonic phrase, go to the mobile app: Settings (gear icon) -> Advanced -> Recovery Phrase.
+#### Farcaster account information
+
+-   Get a dev account for Farcaster and save your main account's mnemonic phrase.
+-   To find the mnemonic phrase, go to the mobile app: Settings (gear icon) -> Advanced -> Recovery Phrase.
     ```bash
     NEXT_PUBLIC_APP_MNEMONIC = 'candy maple cake sugar honey ... potato blue'
     ```
-  - Find your FID in your account's About information. It is labeled as `FID`, e.g., `FID: 1234`.
+-   Find your FID in your account's About information. It is labeled as `FID`, e.g., `FID: 1234`.
     ```bash
     NEXT_PUBLIC_APP_FID = '123'
     ```
 
-  #### Supabase API information
-  - Start your local Supabase instance:
+#### Docker
+
+-   If you don't have Docker installed, you can download it from [here](https://docs.docker.com/get-docker/).
+-   Once installed, make sure Docker daemon is running. You can test it by running `docker ps` in your terminal. If it fails, you will need to start the Docker daemon.
+
+#### Supabase API information
+
+-   Start your local Supabase instance:
     ```bash
     supabase start
     ```
     This may take a while to download all the containers and get started.
-  - Once it's done, find the 'API KEY' and 'anon key' by running the command:
+-   Once it's done, find the 'API KEY' and 'anon key' by running the command:
     ```bash
     supabase status
     ```
     Save them as:
     ```bash
-    NEXT_PUBLIC_SUPABASE_URL = '<API KEY>'
+    NEXT_PUBLIC_SUPABASE_URL = '<API URL>'
     NEXT_PUBLIC_SUPABASE_ANON_KEY = '<anon key>'
     ```
 
 6. Set up accounts table signer encryption in your SQL Editor:
-  - Generate a private encryption key:
+
+-   Open the Studio URL in the browser and navigate to the SQL Editor tab
+-   Generate a private encryption key:
     ```sql
     SELECT * FROM pgsodium.create_key();
     ```
-  - Get the key ID:
+-   Get the key ID (copy the id obtained, as it is needed in the next command):
     ```sql
     SELECT id FROM pgsodium.valid_key LIMIT 1;
     ```
-  - Run the following command:
+-   Run the following command (replace <PG_SODIUM_KEY> with the id from the previous command):
     ```sql
     SECURITY LABEL FOR "pgsodium" ON COLUMN "public"."accounts"."private_key" IS 'ENCRYPT WITH KEY ID <PG_SODIUM_KEY> SECURITY INVOKER';
     ```
+    You should get the response "Success. No rows returned" indicating that the command was successful and returned no rows.
 
 7. Run the local app in development mode:
-  ```bash
-  yarn dev
-  ```
-  This will output:
-  ```bash
-  $ next dev
-    - Local:        http://localhost:3000
-    - Environments: .env.development.local, .env.development
-  ...
-  ✓ Ready in 2.4s
-  ```
-  Click the localhost link to open the app in your browser. If the compilation fails due to missing .env variables, double-check the spelling of the variable names.
+
+```bash
+yarn dev
+```
+
+This will output:
+
+```bash
+$ next dev
+  - Local:        http://localhost:3000
+  - Environments: .env.development.local, .env.development
+...
+✓ Ready in 2.4s
+```
+
+Click the localhost link to open the app in your browser. If the compilation fails due to missing .env variables, double-check the spelling of the variable names.
 
 Congratulations! You now have a local version of herocast working.
 


### PR DESCRIPTION
The PR Improved the guide in the CONTRIBUTING.md for new contributors. expecially those that are new to supabase

Changes made

- Docker section - Ensures that the new contributor have their docker daemon running before running the `supabase start` command. Also linked to docker installation manual page in a case where they don't have it installed
- Corrected the value set for NEXT_PUBLIC_SUPABASE_URL - says` <API KEY>` instead of `<API URL>`
- Make the "Set up accounts table signer encryption" steps clearer