### PR TITLE
fix(hypersnap): route trending, user search, bulk casts to Neynar fallback

### DIFF
--- a/src/lib/farcaster/providers/hypersnap.ts
+++ b/src/lib/farcaster/providers/hypersnap.ts
@@ -58,11 +58,11 @@ export function createHypersnapProvider(): FarcasterProvider {
     type: 'hypersnap',
 
     capabilities: {
-      trendingFeed: true,
+      trendingFeed: false,
       profileCasts: true,
       profileLikes: true,
       fidListFeed: false,
-      castLookup: true,
+      castLookup: false,
       allChannels: true,
     },
 
@@ -78,9 +78,9 @@ export function createHypersnapProvider(): FarcasterProvider {
       return data.user;
     },
 
-    async searchUsers({ q, limit, signal }) {
-      const data = await fetchJson<{ users: FarcasterUser[] }>(buildUrl('user/search', { q, limit }), signal);
-      return data.users || [];
+    searchUsers() {
+      // Hypersnap user search is exact-prefix only — no fuzzy/display-name match. Fall back to Neynar.
+      return unsupported('searchUsers');
     },
 
     async getBulkUsers({ fids, signal }) {
@@ -92,8 +92,9 @@ export function createHypersnapProvider(): FarcasterProvider {
       return fetchJson<FeedResponse>(buildUrl('feed', { feed_type: 'following', fid, limit, cursor }), signal);
     },
 
-    async getTrendingFeed({ limit = 10, cursor, signal }) {
-      return fetchJson<FeedResponse>(buildUrl('feed/trending', { limit, cursor }), signal);
+    getTrendingFeed() {
+      // Hypersnap /feed/trending currently takes ~54s per call. Fall back to Neynar until upstream fix.
+      return unsupported('getTrendingFeed');
     },
 
     async getChannelFeed({ parentUrl, limit = 15, cursor, signal }) {
@@ -144,12 +145,9 @@ export function createHypersnapProvider(): FarcasterProvider {
       return { results, next: { cursor: undefined } } satisfies SearchCastsResponse;
     },
 
-    async getCasts({ hashes, signal }) {
-      const data = await fetchJson<{ casts: FarcasterCast[] }>(
-        buildUrl('cast/bulk', { hashes: hashes.join(',') }),
-        signal
-      );
-      return data.casts || [];
+    getCasts() {
+      // Hypersnap /cast/bulk omits viewer_context, so has_liked/has_recasted UI state would be wrong.
+      return unsupported('getCasts');
     },
 
     async getChannel({ id, signal }) {


### PR DESCRIPTION
**Stacked on #710** — target this PR's base to `main` once #710 merges.

## Why

Empirical probes against `haatz.quilibrium.com/v2/farcaster` (live tests in conversation, summary below) revealed three issues that make those methods unsuitable for the hypersnap path. The FallbackProvider already handles `UnsupportedProviderFeatureError` transparently, so reverting these three methods to throw routes them to Neynar with zero consumer changes.

### 1. Trending feed: ~54 seconds per call

| Endpoint | p50 latency |
|---|---|
| `/feed/trending?limit=15` | **~54,000ms** |
| `/feed?feed_type=trending` | ~58,000ms |
| `/feed?feed_type=for_you` | ~58,000ms |
| `/feed?feed_type=following` (for comparison) | 232ms |

Three back-to-back calls all returned in ~54s, so no warm-cache effect. Neynar trending returns in 1-2s. Our perf threshold is 1000ms — every trending fetch on hypersnap would log `critical`.

### 2. `user/search` is exact-prefix only

| Query | Hypersnap result |
|---|---|
| `dwr` | 1 user (exact: `dwr`) |
| `dwr.eth` | 0 users (no ENS suffix matching) |
| `hell` | 1 user (exact: `hell`) |

No fuzzy/display-name/bio ranking. Autocomplete UX (typing `vita` to find `vitalik`) is broken vs Neynar.

### 3. `cast/bulk` omits `viewer_context`

Confirmed via `has("viewer_context") = false` in response. `has_liked` and `has_recasted` icons would render incorrectly on the hypersnap path — visible UI bug on every feed.

## What changes

- `getTrendingFeed`, `searchUsers`, `getCasts` revert to `unsupported(...)` throws (one-line each)
- `capabilities.trendingFeed: false`, `capabilities.castLookup: false`
- FallbackProvider catches `UnsupportedProviderFeatureError` and silently retries on Neynar

## What stays on hypersnap

`getFollowingFeed`, `getProfileCasts`, `getProfileLikes`, `getChannelFeed`, `getChannel`, `searchChannels`, `getAllChannels`, `getNotifications`, `getUser`, `getUserByUsername`, `getBulkUsers`, `searchCasts` (keyword-only; filtered queries still fall back).

## Followups not in this PR (upstream-side)

- Hypersnap trending performance (54s)
- Hypersnap `/user/by-username?username=foo.eth` returning 404 when stored fname is `foo.eth` (one-way `.eth` strip)
- Hypersnap user search ranking
- `getProfileLikes` cursor support (currently capped at 100 server-side)

## Test plan

- [x] `pnpm check` — 102 tests pass, same 3 pre-existing warnings as #710
- [ ] Manual: toggle Hypersnap, verify trending loads via Neynar (no 54s wait)
- [ ] Manual: user autocomplete still fuzzy-matches on Hypersnap
- [ ] Manual: heart/recast icons reflect viewer state correctly on Hypersnap