### PR TITLE
fix(inbox): prevent wide embeds from squeezing sidebars

### DIFF
--- a/app/(app)/inbox/page.tsx
+++ b/app/(app)/inbox/page.tsx
@@ -945,7 +945,7 @@ const Inbox = () => {
     // Handle follow notifications
     if (isFollow && notification.follows) {
       return (
-        <div className="flex-1 border-l border-muted flex flex-col">
+        <div className="flex-1 min-w-0 border-l border-muted flex flex-col">
           <div className="px-4 py-3 border-b border-muted/50 bg-muted/30">
             <h3 className="text-sm font-medium text-foreground">
               {notification.follows.length} New Follower{notification.follows.length > 1 ? 's' : ''}
@@ -966,7 +966,7 @@ const Inbox = () => {
     if (!notification.cast) return null;
 
     return (
-      <div className="flex-1 border-l border-muted flex flex-col">
+      <div className="flex-1 min-w-0 border-l border-muted flex flex-col">
         {/* Show parent cast for replies and mentions */}
         {isReplyOrMention && (
           <div className="border-b border-muted/50">
@@ -1127,7 +1127,7 @@ const Inbox = () => {
       {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
         {/* Notifications list */}
-        <div className="w-1/2 flex flex-col">
+        <div className="w-1/2 min-w-0 flex flex-col">
           <div className="flex-1 overflow-hidden" ref={listContainerRef}>
             {isEmpty(notifications) && !loadingByType[activeTab] ? (
               <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
## Summary
- Two flex children in the inbox two-pane layout (`app/(app)/inbox/page.tsx`) were missing `min-w-0`.
- With `min-width: auto` (the flex default), a reply containing a wide embed (image, iframe, link card) forced the detail pane to grow to fit the embed's intrinsic width, pushing the parent column wider and visually compressing the left/right sidebars.
- Adding `min-w-0` to the list pane (`w-1/2`) and the detail pane (`flex-1`) lets them shrink, so the embed is clipped within its 50% slot and the sidebars stay fixed.

This is the same recurring pattern called out in `CLAUDE.md` under "Layout Architecture → Scroll Containers".

Closes #713

## Test plan
- [ ] Open `/inbox`, switch to the Replies tab
- [ ] Select a reply with no embed — confirm sidebar widths are unchanged from baseline
- [ ] Select a reply containing a wide embed (image / link card / iframe) — confirm left and right sidebar widths do not change
- [ ] Switch between embed and non-embed replies repeatedly — sidebars stay fixed
- [ ] Verify the detail pane still renders the embed correctly within its 50% slot