### PR TITLE
fix(editor): restore Cmd+Enter to publish in single-cast modal

### DIFF
--- a/src/common/components/Editor/NewCastEditor.tsx
+++ b/src/common/components/Editor/NewCastEditor.tsx
@@ -207,20 +207,9 @@ export default function NewPostEntry({
     }
   };
 
-  // Cmd+Enter: Add another cast to thread
-  const ref = useAppHotkeys(
-    'meta+enter',
-    handleAddCast,
-    {
-      scopes: [HotkeyScopes.EDITOR],
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-      preventDefault: true,
-    },
-    [handleAddCast]
-  );
+  const isThreadContext = !!draft.threadId || !!onAddCast;
 
-  // Cmd+Shift+Enter: Publish single cast or thread
+  // Cmd+Enter publishes; inside a thread it adds the next post (Cmd+Shift+Enter still publishes).
   useAppHotkeys(
     'meta+shift+enter',
     onSubmitPost,
@@ -231,6 +220,18 @@ export default function NewPostEntry({
       preventDefault: true,
     },
     [onSubmitPost, draft, account, isHydrated]
+  );
+
+  const ref = useAppHotkeys(
+    'meta+enter',
+    isThreadContext ? handleAddCast : onSubmitPost,
+    {
+      scopes: [HotkeyScopes.EDITOR],
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
+      preventDefault: true,
+    },
+    [isThreadContext, handleAddCast, onSubmitPost, draft, account, isHydrated]
   );
 
   const { uploadImage, isUploading, error, image } = useCloudinaryUpload();


### PR DESCRIPTION
## Summary
- `Cmd+Enter` was remapped to "add post to thread" when the unified thread composer shipped (#666). The single-cast modal lost its familiar publish shortcut, even though `hotkeyDefinitions.ts` still advertised `meta+enter` as "Submit Post".
- Made the binding context-aware in `NewCastEditor.tsx`: branches on `!!draft.threadId || !!onAddCast`. Single-cast modal → publish. Thread composer → add next post (unchanged).
- `Cmd+Shift+Enter` still always publishes, so threads continue to ship from the keyboard.

## Test plan
- [ ] Open new cast modal (press `c`), type something, hit `Cmd+Enter` → cast publishes
- [ ] Open new cast modal as a reply, hit `Cmd+Enter` → reply publishes
- [ ] Open thread composer (`/post` with multi-post draft), hit `Cmd+Enter` in any post → new empty post appended
- [ ] In thread composer, hit `Cmd+Shift+Enter` → entire thread publishes
- [ ] In single-cast modal, hit `Cmd+Shift+Enter` → still publishes