### PR TITLE
fix(sidebar): show viewed profile on /profile/<slug> (#712)

### DIFF
--- a/src/common/components/Sidebar/AuthorContextPanel.tsx
+++ b/src/common/components/Sidebar/AuthorContextPanel.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy, ExternalLink, Github, Twitter } from 'lucide-react';
 import Link from 'next/link';
+import { useParams, usePathname } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import ProfileInfoContent from '@/common/components/ProfileInfoContent';
 import {
@@ -22,24 +23,47 @@ type ExtendedProfile = {
   }>;
 };
 
+const APP_FID = Number(process.env.NEXT_PUBLIC_APP_FID!);
+
+const getUsernameAndFidFromSlug = (slug?: string) => {
+  if (!slug) {
+    return { username: undefined, fid: undefined };
+  }
+  const fid = slug.startsWith('fid:') ? slug.slice(4) : undefined;
+  if (fid) {
+    return { username: undefined, fid: Number(fid) };
+  }
+  const username = slug.startsWith('@') ? slug.slice(1) : slug;
+  return { username, fid: undefined };
+};
+
 const AuthorContextPanel = () => {
-  const { selectedCast } = useNavigationStore();
+  const { selectedCast, selectedProfileFid } = useNavigationStore();
   const currentAccount = useAccountStore((state) => state.accounts[state.selectedAccountIdx]);
   const currentUserFid = currentAccount?.platformAccountId ? Number(currentAccount.platformAccountId) : undefined;
 
-  // If cast selected, show cast author. Otherwise show current user
-  const targetFid = selectedCast?.author?.fid || currentUserFid;
+  const pathname = usePathname();
+  const params = useParams();
+  const isOnProfileRoute = pathname.startsWith('/profile/');
+  const { fid: routeFid, username: routeUsername } = isOnProfileRoute
+    ? getUsernameAndFidFromSlug(params.slug as string)
+    : { fid: undefined, username: undefined };
 
-  const { data: profile, isLoading } = useProfile(
-    { fid: targetFid },
-    {
-      viewerFid: currentUserFid,
-      enabled: !!targetFid,
-    }
-  );
+  const fallbackFid = selectedCast?.author?.fid ?? selectedProfileFid ?? currentUserFid;
 
-  const isShowingCurrentUser = !selectedCast && !!currentUserFid;
-  const displayProfile = profile || selectedCast?.author;
+  const profileParams = isOnProfileRoute ? { fid: routeFid, username: routeUsername } : { fid: fallbackFid };
+  const profileEnabled = isOnProfileRoute ? !!(routeFid || routeUsername) : !!fallbackFid;
+  const profileViewerFid = currentUserFid ?? (isOnProfileRoute ? APP_FID : undefined);
+
+  const { data: profile, isLoading } = useProfile(profileParams, {
+    viewerFid: profileViewerFid,
+    includeAdditionalInfo: isOnProfileRoute,
+    enabled: profileEnabled,
+  });
+
+  const targetFid = isOnProfileRoute ? profile?.fid : fallbackFid;
+  const isShowingCurrentUser = !isOnProfileRoute && !selectedCast && !selectedProfileFid && !!currentUserFid;
+  const displayProfile = profile || (isOnProfileRoute ? undefined : selectedCast?.author);
   const extendedProfile = displayProfile as (typeof displayProfile & ExtendedProfile) | undefined;
 
   const unknownAppFids = useMemo(() => {
@@ -72,7 +96,7 @@ const AuthorContextPanel = () => {
     return `${address.slice(0, 6)}...${address.slice(-4)}`;
   };
 
-  if (!targetFid) {
+  if (!targetFid && !isOnProfileRoute) {
     return (
       <Sidebar side="right" collapsible="none" className="border-l border-sidebar-border/50 w-full hidden lg:flex">
         <SidebarContent className="p-4">


### PR DESCRIPTION
## Summary
- On `/profile/<slug>`, the right-sidebar `AuthorContextPanel` fell back to the viewer's own profile under a "Your Profile" header instead of the profile being viewed (issue #712).
- Drive the panel directly from the URL slug when on a profile route, bypassing the `selectedCast` / `selectedProfileFid` / `currentUserFid` chain entirely (which had a stale-cast leak from `/feeds` and a "Your Profile" misfire).
- Pass `viewerFid` and `includeAdditionalInfo` matching the page so React Query dedupes both calls to a single fetch.

Fixes #712

## Test plan
- [ ] Cold-load `/profile/stephancill` while logged in → sidebar shows stephancill, no "Your Profile" header
- [ ] `/feeds` → select a cast → navigate to `/profile/<other-user>` → sidebar shows that user (no stale cast author)
- [ ] `/profile/X` → `/profile/Y` → sidebar updates to Y
- [ ] `/feeds` with no cast selected → still shows your own profile under "Your Profile" (unchanged)
- [ ] `/dms` with a conversation → still shows participant (unchanged)
- [ ] `/profile/<username>` while logged out → loading skeleton, then profile (uses `APP_FID` fallback)