### PR TITLE
fix(editor): route @username autocomplete through provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,6 @@
 # those changes
 NEXT_PUBLIC_VERCEL_ENV = development
 NEXT_PUBLIC_URL = 'http://localhost:3000'
-NEXT_PUBLIC_MOD_PROTOCOL_API_URL = 'https://api.modprotocol.org/api'
 
 # The following are sensative data and should
 # be stored in a .env.development.local file

--- a/src/common/components/Editor/NewCastEditor.tsx
+++ b/src/common/components/Editor/NewCastEditor.tsx
@@ -1,4 +1,3 @@
-import { getFarcasterMentions } from '@mod-protocol/farcaster';
 import { EditorContent } from '@tiptap/react';
 import { format, startOfToday } from 'date-fns';
 import { take } from 'lodash';
@@ -15,6 +14,7 @@ import { useAppHotkeys } from '@/common/hooks/useAppHotkeys';
 import { useCastEditor } from '@/common/hooks/useCastEditor';
 import { useChannelLookup } from '@/common/hooks/useChannelLookup';
 import { useCloudinaryUpload } from '@/common/hooks/useCloudinaryUpload';
+import type { FarcasterMention } from '@/common/types/embeds';
 import type { FarcasterChannel } from '@/common/types/farcaster';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
@@ -35,9 +35,6 @@ import { ChannelList } from '../ChannelList';
 import { ChannelPicker } from '../ChannelPicker';
 import { MentionList } from '../MentionsList';
 import { EmbedsEditor } from './EmbedsEditor';
-
-const API_URL = process.env.NEXT_PUBLIC_MOD_PROTOCOL_API_URL!;
-const getMentions = getFarcasterMentions(API_URL);
 
 // fetchUrlMetadata - simplified version (we don't use this for now, images go direct to cloudinary)
 const fetchUrlMetadata = async (url: string): Promise<Record<string, unknown>> => {
@@ -275,12 +272,23 @@ export default function NewPostEntry({
   // Create enhanced mention configuration that captures FIDs
   const mentionConfig = useMemo(() => {
     return createRenderMentionsSuggestionConfig({
-      getResults: async (query: string) => {
+      getResults: async (query: string): Promise<FarcasterMention[]> => {
+        if (query.length < 1) return [];
         try {
-          const results = await getMentions(query);
+          const rawFid = account?.platformAccountId ?? process.env.NEXT_PUBLIC_APP_FID;
+          const parsedFid = rawFid ? Number(rawFid) : Number.NaN;
+          const viewerFid = Number.isFinite(parsedFid) ? parsedFid : undefined;
+          const users = await getProvider().searchUsers({ q: query, viewerFid, limit: 5 });
+          const results: FarcasterMention[] = users.map((u) => ({
+            fid: u.fid,
+            username: u.username,
+            display_name: u.display_name,
+            avatar_url: u.pfp_url,
+            pfp_url: u.pfp_url,
+          }));
           // When results come back, check if any have FIDs and capture them
           // Use setTimeout to avoid state updates during render
-          if (results && Array.isArray(results)) {
+          if (results.length > 0) {
             setTimeout(() => {
               const newMentions = {};
               results.forEach((mention) => {
@@ -304,7 +312,7 @@ export default function NewPostEntry({
       },
       RenderList: MentionList,
     });
-  }, []);
+  }, [account?.platformAccountId]);
 
   const handleContentChange = useCallback(
     (text: string) => {


### PR DESCRIPTION
## Summary

- Replaces the dead `getFarcasterMentions` mod-protocol API in the composer with `getProvider().searchUsers()` — the same path Cmd+K user search and `ProfileSearchDropdown` use.
- Guards `viewerFid` against `NaN` (parse + `Number.isFinite`, fall back to `undefined` so the param is omitted rather than sent as `viewer_fid=NaN`).
- Allows 1-character Farcaster handles (e.g. `@v`) — only blocks fetches on the bare `@` trigger.
- Drops the stale `NEXT_PUBLIC_MOD_PROTOCOL_API_URL` from `.env.example`.

Closes #720.

## Why

`api.modprotocol.org/api/farcaster/mentions` returns `200 OK` with an empty results array for every query (probed 2026-05-15). User-visible impact: typing `@anything` in the composer showed a spinner that resolved to "Not found" — every time, regardless of the Neynar/Hypersnap provider toggle, because the editor never routed through our provider abstraction. After the recent provider work, `searchUsers` works on both Neynar and Hypersnap and is the canonical user-search entrypoint.

## Test plan

- [ ] Type `@dwr` in the editor → Dan Romero (or whoever the prefix matches on the active provider) appears within ~300ms
- [ ] Type `@anything-that-doesnt-exist` → "Not found" renders (no infinite spinner)
- [ ] Type a 1-char handle (`@v`) → fetch fires and results render (regression guard from review)
- [ ] Pick a mention from the dropdown, publish the draft, confirm `draft.mentionsToFids[username]` was populated and the cast contains the correct mentioned FID
- [ ] Cmd+K user search still works (shared provider path)
- [ ] Channel picker (`/`) still works
- [ ] Run `pnpm typecheck`

## Known follow-up

There's a pre-existing latent bug: `useCastEditor.ts:145` calls `useTipTapEditor` without a deps array, so the Mention extension's `suggestion` config is captured once at mount. Switching accounts mid-session won't re-thread the new `viewerFid` into the live editor. Tracked separately — out of scope for this fix because the previous behavior had the same limitation (and worse: it returned `[]` for every query anyway).