### PR TITLE
fix(editor): refresh mention viewerFid on account switch

### DIFF
--- a/src/common/components/Editor/NewCastEditor.tsx
+++ b/src/common/components/Editor/NewCastEditor.tsx
@@ -129,6 +129,12 @@ export default function NewPostEntry({
 
   const lastSetTextRef = useRef<string | undefined>(draft.text);
 
+  // Read viewerFid via ref inside extension closures because useTipTapEditor has no deps array (see #723)
+  const viewerFidRef = useRef<string | undefined>(account?.platformAccountId);
+  useEffect(() => {
+    viewerFidRef.current = account?.platformAccountId;
+  }, [account?.platformAccountId]);
+
   // Use on-demand channel lookup for draft's parent URL
   const { channel: draftChannel } = useChannelLookup(draft.parentUrl);
 
@@ -275,7 +281,7 @@ export default function NewPostEntry({
       getResults: async (query: string): Promise<FarcasterMention[]> => {
         if (query.length < 1) return [];
         try {
-          const rawFid = account?.platformAccountId ?? process.env.NEXT_PUBLIC_APP_FID;
+          const rawFid = viewerFidRef.current ?? process.env.NEXT_PUBLIC_APP_FID;
           const parsedFid = rawFid ? Number(rawFid) : Number.NaN;
           const viewerFid = Number.isFinite(parsedFid) ? parsedFid : undefined;
           const users = await getProvider().searchUsers({ q: query, viewerFid, limit: 5 });
@@ -312,7 +318,7 @@ export default function NewPostEntry({
       },
       RenderList: MentionList,
     });
-  }, [account?.platformAccountId]);
+  }, []);
 
   const handleContentChange = useCallback(
     (text: string) => {

--- a/src/common/hooks/useCastEditor.ts
+++ b/src/common/hooks/useCastEditor.ts
@@ -142,6 +142,8 @@ export function useCastEditor({
   // TipTap editor
   // immediatelyRender: false is required for SSR/Next.js to avoid hydration mismatches
   // See: https://tiptap.dev/docs/editor/getting-started/install/nextjs
+  // No deps array on useEditor by design — editor instance survives renders. Extension configs
+  // (suggestion handlers, paste/drop) are captured once at mount; read mutable state via refs (see #723).
   const editor = useTipTapEditor({
     extensions,
     content: '',


### PR DESCRIPTION
## Summary

- Lift `account?.platformAccountId` into a ref synced via `useEffect` and read `viewerFidRef.current` inside the mention `getResults` closure.
- Revert `mentionConfig` `useMemo` deps to `[]` so the config is truly stable.
- Add a guardrail comment at the `useTipTapEditor` call site documenting the no-deps-array contract.

Closes #723.

## Why

`useEditor` from `@tiptap/react` constructs the editor exactly once at mount when called without a deps array (`src/common/hooks/useCastEditor.ts:147`). The Mention extension's `suggestion.items` closure captured `account?.platformAccountId` at first render, so switching accounts mid-compose kept sending the original `viewer_fid` to `getProvider().searchUsers()`. The recent `useMemo([account?.platformAccountId])` around `mentionConfig` recomputed a fresh config object, but it never reached the live editor.

### Why ref instead of `useEditor` deps array

Adding `[account?.platformAccountId]` to `useTipTapEditor` would recreate the editor on account switch. The existing init effect at `NewCastEditor.tsx:382-419` would NOT re-apply draft text — `isDraftSwitch` is false (`draft.id` unchanged) and `isExternalStoreChange` is false (`draft.text === lastSetTextRef.current`) — so the new editor would mount blank with the user's draft hidden. The ref approach keeps the editor instance alive, preserving cursor, draft text, embeds, channel selection, and focus.

Validated by an independent codex review pass (verdict: correct, no regressions, race window is acceptable since `useEffect` ref-sync runs in the commit phase before the next keystroke can fire a query).

## Test plan

- [ ] Open composer as account A, type `@dwr`, observe Network tab → `viewer_fid` matches account A's FID
- [ ] Switch to account B without closing the composer
- [ ] Type another `@` query → `viewer_fid` is now account B's FID (next query, not requiring a remount)
- [ ] Confirm draft text, embeds, and selected channel survive the account switch
- [ ] Cursor position is not reset by account switch
- [ ] `pnpm run typecheck` passes (verified locally)