### PR TITLE
fix(feed): filter replies from Hypersnap following feed

### DIFF
--- a/src/lib/farcaster/providers/__tests__/hypersnap.test.ts
+++ b/src/lib/farcaster/providers/__tests__/hypersnap.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createHypersnapProvider } from '../hypersnap';
+
+// Avoid pulling in zustand/posthog via the real performance store — just run the work.
+jest.mock('@/stores/usePerformanceStore', () => ({
+  measureAsync: <T>(_name: string, fn: () => Promise<T>) => fn(),
+}));
+
+type FeedCast = { hash: string; parent_hash: string | null; parent_url?: string };
+
+describe('createHypersnapProvider.getFollowingFeed', () => {
+  const provider = createHypersnapProvider();
+  let fetchMock: jest.Mock<(input: unknown, init?: unknown) => Promise<unknown>>;
+
+  beforeEach(() => {
+    fetchMock = jest.fn<(input: unknown, init?: unknown) => Promise<unknown>>();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockFeed(casts: FeedCast[], cursor: string | undefined = 'CURSOR_123') {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ casts, next: { cursor } }),
+    });
+  }
+
+  it('drops replies and keeps only root casts', async () => {
+    mockFeed([
+      { hash: '0xroot1', parent_hash: null },
+      { hash: '0xreply1', parent_hash: '0xparentA' },
+      { hash: '0xroot2', parent_hash: null },
+      { hash: '0xreply2', parent_hash: '0xparentB' },
+    ]);
+
+    const res = await provider.getFollowingFeed({ fid: 3, limit: 15 });
+
+    expect(res.casts.map((c) => c.hash)).toEqual(['0xroot1', '0xroot2']);
+  });
+
+  it('keeps channel root casts (parent_url set, no parent_hash)', async () => {
+    mockFeed([{ hash: '0xchannelroot', parent_hash: null, parent_url: 'https://warpcast.com/~/channel/degen' }]);
+
+    const res = await provider.getFollowingFeed({ fid: 3, limit: 15 });
+
+    expect(res.casts.map((c) => c.hash)).toEqual(['0xchannelroot']);
+  });
+
+  it('preserves the upstream pagination cursor after filtering', async () => {
+    mockFeed([{ hash: '0xreply1', parent_hash: '0xparentA' }], 'NEXT_PAGE');
+
+    const res = await provider.getFollowingFeed({ fid: 3, limit: 15 });
+
+    expect(res.casts).toEqual([]);
+    expect(res.next?.cursor).toBe('NEXT_PAGE');
+  });
+
+  it('over-fetches to compensate for filtered replies', async () => {
+    mockFeed([]);
+
+    await provider.getFollowingFeed({ fid: 3, limit: 15 });
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('limit=45'); // 15 * 3
+  });
+
+  it('caps the over-fetch at the upstream maximum of 100', async () => {
+    mockFeed([]);
+
+    await provider.getFollowingFeed({ fid: 3, limit: 50 });
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('limit=100'); // 50 * 3 -> capped
+  });
+});

--- a/src/lib/farcaster/providers/hypersnap.ts
+++ b/src/lib/farcaster/providers/hypersnap.ts
@@ -13,6 +13,14 @@ import { UnsupportedProviderFeatureError as UnsupportedFeatureError } from './ty
 const PROVIDER = 'hypersnap' as const;
 const DIRECT_UPSTREAM = 'https://haatz.quilibrium.com/v2/farcaster';
 
+// Hypersnap's /feed/following interleaves replies with root casts (only ~15-20% are root
+// casts), so after dropping replies a raw fetch surfaces few top-level casts. We over-fetch
+// modestly to thicken each fetch. The feed is a continuous infinite scroll that keeps
+// fetching while the bottom sentinel stays in view, so a small multiplier is enough — the
+// scroll loop tops up the rest. Capped at the upstream max limit of 100.
+const FOLLOWING_FEED_OVERFETCH = 3;
+const FOLLOWING_FEED_MAX_LIMIT = 100;
+
 // SSR safety: `src/lib/farcaster/providers/index.ts` is `'use client'` and `getProviderType()`
 // returns 'neynar' when `window` is undefined, so this provider is never constructed server-side
 // via `getProvider()`. The SSR branch below is defensive only — route handlers must not call
@@ -119,7 +127,17 @@ export function createHypersnapProvider(): FarcasterProvider {
     },
 
     async getFollowingFeed({ fid, limit = 15, cursor, signal }) {
-      return fetchJson<FeedResponse>(buildUrl('feed/following', { fid, limit, cursor }), signal);
+      // Unlike Neynar's following feed (root-only), Hypersnap returns replies inline and
+      // ignores reply-filter params (with_replies, include_replies, filter_type, ...), so
+      // we filter client-side to match the native contract. Over-fetch to compensate, then
+      // return every root cast in the window (no truncation) so the cursor advances by the
+      // full upstream window and pagination never skips casts.
+      const fetchLimit = Math.min(FOLLOWING_FEED_MAX_LIMIT, limit * FOLLOWING_FEED_OVERFETCH);
+      const data = await fetchJson<FeedResponse>(
+        buildUrl('feed/following', { fid, limit: fetchLimit, cursor }),
+        signal
+      );
+      return { ...data, casts: (data.casts ?? []).filter((cast) => !cast.parent_hash) };
     },
 
     getTrendingFeed() {


### PR DESCRIPTION
## Problem

When the **Hypersnap** provider is active, the Following feed shows replies, not just top-level casts — making it confusing. Native (Neynar) didn't have this issue.

**Root cause:** Hypersnap's \`/feed/following\` interleaves replies with root casts (only ~15–20% are root casts), whereas Neynar's following feed is root-only. herocast passed identical params to both providers and assumed identical behavior.

## Why client-side

The Hypersnap API has **no server-side reply filter**. Verified two ways:
- Live-tested \`with_replies\`, \`include_replies\`, \`filter_type=root\`, \`exclude_replies\`, \`with_recasts=false\`, \`should_filter\` on both the dedicated \`/feed/following\` and generic \`/feed?feed_type=following\` endpoints — all ignored.
- Quilibrium's own client (\`quorum-shared\`/\`quorum-mobile\`) sends only \`fid\`/\`cursor\`/\`limit\` and never filters replies (their home feed shows them, matching Farcaster-native behavior).

So filtering client-side is the only path to a root-only feed — mirroring the same fetch-boundary filter pattern Quilibrium uses for scam casts.

## Change

- Filter replies (\`!parent_hash\`) in the Hypersnap provider's \`getFollowingFeed\`, so it covers both consumers (\`feeds/page.tsx\`, \`FeedPanel.tsx\`) and the single-page hook.
- Over-fetch 3× (capped at the upstream max of 100) to thicken each fetch after replies are dropped; the infinite-scroll loop tops up the rest until the screen fills.
- Return every root cast in the window (no truncation) so the upstream cursor advances correctly and pagination never skips casts.
- Channel root casts (\`parent_url\` set, no \`parent_hash\`) are kept.

## Tests

Added \`src/lib/farcaster/providers/__tests__/hypersnap.test.ts\` (5 tests): replies dropped, channel roots kept, cursor preserved, over-fetch (15→45), and cap (50→100). Full suite passes (107).