### PR TITLE
fix(editor): restore Cmd+Enter to publish; fix thread publish collision

### DIFF
--- a/src/common/components/Editor/NewCastEditor.tsx
+++ b/src/common/components/Editor/NewCastEditor.tsx
@@ -85,6 +85,7 @@ type NewPostEntryProps = {
   draft: DraftType;
   onPost?: () => void;
   onRemove?: () => void;
+  /** When provided, Cmd+Enter adds the next thread post instead of publishing (thread-composer mode). */
   onAddCast?: () => void;
   hideChannel?: boolean;
   hideSchedule?: boolean;
@@ -152,19 +153,6 @@ export default function NewPostEntry({
     return true;
   };
 
-  const handleAddCast = useCallback(() => {
-    // No need to flush - controlled pattern keeps store in sync immediately
-    if (draft.threadId) {
-      const { addPostToThread } = useDraftStore.getState();
-      // Pass current draft's threadIndex to insert after this draft
-      const newDraftId = addPostToThread(draft.threadId, draft.threadIndex);
-      if (newDraftId) {
-        // Could optionally focus new editor here via onAddCast callback
-      }
-    }
-    onAddCast?.();
-  }, [draft.threadId, draft.threadIndex, onAddCast]);
-
   const onSubmitPost = async (): Promise<boolean> => {
     try {
       if (!isHydrated) return false;
@@ -207,9 +195,9 @@ export default function NewPostEntry({
     }
   };
 
-  const isThreadContext = !!draft.threadId || !!onAddCast;
-
-  // Cmd+Enter publishes; inside a thread it adds the next post (Cmd+Shift+Enter still publishes).
+  // Cmd+Shift+Enter publishes the current cast. In the thread composer (onAddCast present) the
+  // parent owns thread publishing, so each per-post editor disables this to avoid firing a
+  // single-cast publish from every mounted editor.
   useAppHotkeys(
     'meta+shift+enter',
     onSubmitPost,
@@ -218,20 +206,23 @@ export default function NewPostEntry({
       enableOnFormTags: true,
       enableOnContentEditable: true,
       preventDefault: true,
+      enabled: !onAddCast,
     },
     [onSubmitPost, draft, account, isHydrated]
   );
 
+  // Cmd+Enter publishes the cast. The thread composer passes onAddCast, so there it adds the
+  // next post instead (Cmd+Shift+Enter still publishes).
   const ref = useAppHotkeys(
     'meta+enter',
-    isThreadContext ? handleAddCast : onSubmitPost,
+    onAddCast ?? onSubmitPost,
     {
       scopes: [HotkeyScopes.EDITOR],
       enableOnFormTags: true,
       enableOnContentEditable: true,
       preventDefault: true,
     },
-    [isThreadContext, handleAddCast, onSubmitPost, draft, account, isHydrated]
+    [onAddCast, onSubmitPost, draft, account, isHydrated]
   );
 
   const { uploadImage, isUploading, error, image } = useCloudinaryUpload();

--- a/src/common/components/ThreadComposer/ThreadPostCard.tsx
+++ b/src/common/components/ThreadComposer/ThreadPostCard.tsx
@@ -122,6 +122,7 @@ export default function ThreadPostCard({
             hideSubmit={true}
             hideToolbar={!isFirst}
             borderless={true}
+            onAddCast={onAddPost}
           />
         </div>
 


### PR DESCRIPTION
Cmd+Enter stopped publishing in the single-cast modal because every draft carries a `threadId`, making the old `isThreadContext = !!draft.threadId` check always true (and PR #717's fix relied on the same dead signal). This switches the thread-vs-single signal to the presence of the `onAddCast` callback: the modal renders the editor without it (Cmd+Enter publishes), while `ThreadComposer` now passes `onAddCast={onAddPost}` so add-post logic lives solely in the parent (Cmd+Enter adds a post), removing the duplicated `handleAddCast`/`isThreadContext`. It also gates the editor's Cmd+Shift+Enter with `enabled: !onAddCast` so per-card editors in the thread composer no longer each fire a stray single-cast publish alongside the thread publish. Broader modal-over-page hotkey scope leakage is tracked in #729.
