### PR TITLE
fix(settings): restore page scroll and simplify provider copy

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -112,7 +112,7 @@ export default function Settings() {
   };
 
   return (
-    <div className="p-4">
+    <div className="h-full overflow-y-auto p-4">
       <div className="flex flex-col gap-6 max-w-2xl">
         {/* Account Section */}
         <Card>
@@ -169,11 +169,9 @@ export default function Settings() {
           <CardContent className="space-y-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium">{providerType === 'neynar' ? 'Neynar' : 'Hypersnap'}</p>
+                <p className="text-sm font-medium">Provider</p>
                 <p className="text-sm text-muted-foreground">
-                  {providerType === 'neynar'
-                    ? 'Hosted API by Neynar — full feature support'
-                    : 'Hyperchain via cached Herocast proxy — no API key, falls back to Neynar where unsupported'}
+                  {providerType === 'neynar' ? 'Powered by Neynar' : 'Powered by Hypersnap'}
                 </p>
               </div>
               <Button


### PR DESCRIPTION
## What

Two fixes to the **Settings** page (`app/(app)/settings/page.tsx`).

### 1. Page wasn't scrollable
The settings root was `<div className="p-4">` with no height or overflow handling, but the app layout wraps every non-`/accounts` page in a fixed-height `overflow-hidden` container (`src/home/index.tsx`). So once content exceeded the viewport, the **Connections**, **Support**, and **Keyboard Shortcuts** cards were clipped with no way to scroll to them.

Fix: `h-full overflow-y-auto p-4` so the page owns its own scroll, matching the sibling `/accounts` page convention.

### 2. Data Provider copy was AI slop
The old description named a non-existent **"Hyperchain"** (the term appears nowhere else in the codebase — the provider is *Hypersnap*), leaked implementation detail ("cached Herocast proxy — no API key"), and used an em-dash.

Replaced with a symmetric, plain-language label that matches the other rows on the page (`Email`, `Theme`, `Current Layout`):

| | Before | After |
|---|---|---|
| Neynar | Hosted API by Neynar — full feature support | **Provider** / Powered by Neynar |
| Hypersnap | Hyperchain via cached Herocast proxy — no API key, falls back to Neynar where unsupported | **Provider** / Powered by Hypersnap |

Both providers now read identically except for the name — no tradeoff language, no plumbing details.

## Test plan
- [ ] Open Settings; scroll to confirm Connections / Support / Keyboard Shortcuts are reachable
- [ ] Toggle the provider; confirm label reads "Powered by Neynar" / "Powered by Hypersnap"