### PR TITLE
perf(feeds): keep previous feed painted on switch (keepPreviousData)

### DIFF
--- a/src/hooks/queries/useChannelFeed.ts
+++ b/src/hooks/queries/useChannelFeed.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import type { FarcasterCast } from '@/common/types/farcaster';
 import type { FeedResponse } from '@/lib/farcaster/providers';
 import { getProvider } from '@/lib/farcaster/providers';
@@ -45,6 +45,8 @@ export function useChannelFeedInfinite(parentUrl: string, fid: string, options?:
     getNextPageParam: (lastPage) => lastPage.next?.cursor,
     enabled: enabled && !!parentUrl && !!fid,
     staleTime: 1000 * 60 * 2, // 2 minutes for channel feeds
+    // Keep the previous feed painted while the new key loads — no blank frame on switch
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/hooks/queries/useFidListFeed.ts
+++ b/src/hooks/queries/useFidListFeed.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import type { FarcasterCast } from '@/common/types/farcaster';
 import type { FeedResponse } from '@/lib/farcaster/providers';
 import { getProvider } from '@/lib/farcaster/providers';
@@ -66,6 +66,8 @@ export function useFidListFeedInfinite(
     getNextPageParam: (lastPage) => lastPage.next?.cursor,
     enabled: enabled && fids.length > 0 && !!viewerFid,
     staleTime: 1000 * 60 * 2, // 2 minutes for FID list feed
+    // Keep the previous feed painted while the new key loads — no blank frame on switch
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/hooks/queries/useFollowingFeed.ts
+++ b/src/hooks/queries/useFollowingFeed.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import type { FarcasterCast } from '@/common/types/farcaster';
 import type { FeedResponse } from '@/lib/farcaster/providers';
 import { getProvider } from '@/lib/farcaster/providers';
@@ -45,6 +45,8 @@ export function useFollowingFeedInfinite(fid: string, options?: FollowingFeedOpt
     getNextPageParam: (lastPage) => lastPage.next?.cursor,
     enabled: enabled && !!fid,
     staleTime: 1000 * 60 * 2, // 2 minutes for following feed
+    // Keep the previous feed painted while the new key loads — no blank frame on switch
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/hooks/queries/useTrendingFeed.ts
+++ b/src/hooks/queries/useTrendingFeed.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import type { FarcasterCast } from '@/common/types/farcaster';
 import type { FeedResponse } from '@/lib/farcaster/providers';
 import { getProvider } from '@/lib/farcaster/providers';
@@ -44,6 +44,8 @@ export function useTrendingFeedInfinite(options?: TrendingFeedOptions) {
     getNextPageParam: (lastPage) => lastPage.next?.cursor,
     enabled,
     staleTime: 1000 * 60 * 2, // 2 minutes for trending feed
+    // Keep the previous feed painted while the new key loads — no blank frame on switch
+    placeholderData: keepPreviousData,
   });
 }
 


### PR DESCRIPTION
## Summary

Switching channel/feed flashed a blank frame while the next feed loaded, even when we'd just had data. This adds `placeholderData: keepPreviousData` (TanStack Query v5 API) to the feed infinite queries so the previously-loaded feed stays painted until the new query key resolves — no blank frame.

This is **Track A** of #736: a Query-level change that ships immediately on the current Next stack and ports to TanStack Start unchanged. The adjacent/next-feed prefetch-on-hover half (Track B) is deliberately out of scope.

## Changes

Added `import { keepPreviousData }` and `placeholderData: keepPreviousData` to the four infinite feed hooks driving the `/feeds` switcher:

- `useFollowingFeedInfinite` (`useFollowingFeed.ts`)
- `useTrendingFeedInfinite` (`useTrendingFeed.ts`)
- `useChannelFeedInfinite` (`useChannelFeed.ts`)
- `useFidListFeedInfinite` (`useFidListFeed.ts`)

No hook refactor, no new abstraction, no switcher-component change — `app/(app)/feeds/page.tsx` already reads `query.data` / `query.isLoading`, and with placeholder data present `isLoading` stays `false` and the previous casts stay rendered. The existing `inp:switch-feed` instrumentation (`endInteraction('switch-feed', …)`) therefore fires on the very next paint instead of after the network round-trip.

## Where this helps (and where it doesn't)

`keepPreviousData` carries data across a **key change on the same query observer**, so it directly removes the blank frame on:

- **channel → channel** and **list → list** switches (same hook, key changes) — the common, high-frequency case.

Cross-hook switches (following ↔ trending ↔ channel) read a *different* observer, so they're served instantly by the existing 24h `gcTime` cache (PR #750) rather than by this change — consistent with the issue's framing.

**Deliberately excluded** to keep the change minimal:
- **Search-list feed** — `useSearchListFeedInfinite` delegates to the shared `useCastSearchInfinite`, which also powers the interactive `/search` page. Adding placeholder data there would change a separate surface, so I left it out; happy to add it (with the same one-liner) if you'd like search lists covered too.
- **Profile feed tabs** (`useProfileFeed`) — a different surface from the feed/channel switcher, and it switches between separate per-type observers (cross-hook), so `keepPreviousData` wouldn't apply anyway.

## Verification

- `pnpm run lint` (biome) — clean
- `pnpm test` — 128 passed / 10 suites
- `pnpm run build` — **compiles successfully** (`✓ Compiled successfully`); the build then fails at static prerender of `/_not-found` with "Supabase client cannot be created … without environment variables" — this sandbox's `.env.production` has no Supabase secrets, unrelated to this diff.
- **Could not run the app interactively** to read `window.__perfSummary()` — this is a headless container without a browser, Supabase/Neynar credentials, or an authed Farcaster session. By construction, on a same-key switch the previous casts remain painted and `isLoading` is `false`, so `inp:switch-feed` records next-paint latency (well under the 200ms target). Worth a quick manual confirm in a real environment.

Closes #736


---
_Generated by [Claude Code](https://claude.ai/code/session_011Vt4Qgs2jdQo72o9Qc7G9S)_