### PR TITLE
feat(sidebar): surface channels & lists as collapsible feed groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,7 +374,7 @@ Only `warning` and `critical` metrics are sent to PostHog to reduce noise.
 | INP (perceived) | `inp:like`, `inp:recast` | 100ms | `CastRow/ReactionBar.tsx` |
 | INP (perceived) | `inp:open-notification` | 100ms | `app/(app)/inbox/page.tsx` |
 | INP (perceived) | `inp:publish` | 200ms | `Editor/NewCastEditor.tsx` |
-| INP (perceived) | `inp:switch-feed` | 200ms | `Sidebar/ChannelsOverview.tsx`, `Sidebar/ManageListsOverview.tsx` + `feeds/page.tsx` |
+| INP (perceived) | `inp:switch-feed` | 200ms | `Sidebar/feeds/useSidebarFeeds.ts` + `feeds/page.tsx` |
 | INP (perceived) | `inp:open-profile` | 200ms | `CastRow/Author.tsx`, `ProfileHoverCard.tsx` + `profile/[slug]/page.tsx` |
 | INP (perceived) | `inp:cold-start` | 200ms | `app/(app)/feeds/page.tsx` |
 | INP (page-level) | `inp:page` | 200ms | `useWebVitals` hook (`web-vitals` `onINP`) |

--- a/src/common/components/Sidebar/LeftSidebarNav.tsx
+++ b/src/common/components/Sidebar/LeftSidebarNav.tsx
@@ -1,11 +1,10 @@
 import {
-  Hash,
   Inbox,
   LayoutPanelLeft,
-  List,
   MessageCircle,
   Newspaper,
   PenSquare,
+  Plus,
   Search,
   Settings,
   User,
@@ -16,6 +15,10 @@ import { usePathname } from 'next/navigation';
 import type React from 'react';
 import { cn } from '@/lib/utils';
 import { renderShortcut } from './CollapsibleNavSection';
+import { SidebarFeedList } from './feeds/SidebarFeedList';
+import { SidebarFeedSection } from './feeds/SidebarFeedSection';
+import { useCollapsedSections } from './feeds/useCollapsedSections';
+import { useSidebarFeeds } from './feeds/useSidebarFeeds';
 
 type NavItem = {
   name: string;
@@ -25,6 +28,8 @@ type NavItem = {
   additionalPaths?: string[];
 };
 
+// Lists & Channels are no longer flat links — they live as collapsible groups in
+// the feeds disclosure below, surfacing the user's actual channels and lists.
 const mainNavItems: NavItem[] = [
   {
     name: 'Feeds',
@@ -62,16 +67,6 @@ const mainNavItems: NavItem[] = [
     icon: <Search className="h-5 w-5" />,
     shortcut: '/',
   },
-  {
-    name: 'Lists',
-    href: '/lists',
-    icon: <List className="h-5 w-5" />,
-  },
-  {
-    name: 'Channels',
-    href: '/channels',
-    icon: <Hash className="h-5 w-5" />,
-  },
 ];
 
 const bottomNavItems: NavItem[] = [
@@ -100,8 +95,39 @@ type LeftSidebarNavProps = {
   onNavigate?: () => void;
 };
 
+/** Footer action under a feeds group — links to the relevant management page. */
+function SectionFooterLink({
+  href,
+  label,
+  onNavigate,
+  active,
+}: {
+  href: string;
+  label: string;
+  onNavigate?: () => void;
+  active?: boolean;
+}) {
+  return (
+    <Link href={href} onClick={onNavigate}>
+      <span
+        className={cn(
+          'flex items-center gap-x-2 rounded-md px-2 py-1.5 text-xs font-medium transition-colors',
+          active
+            ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+            : 'text-sidebar-foreground/55 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'
+        )}
+      >
+        <Plus className="h-3.5 w-3.5" />
+        {label}
+      </span>
+    </Link>
+  );
+}
+
 const LeftSidebarNav = ({ onNavigate }: LeftSidebarNavProps) => {
   const pathname = usePathname() || '/';
+  const { customFeeds, channels, lists, selectedId, isHydrated, selectFeed } = useSidebarFeeds(onNavigate);
+  const { isOpen, toggle } = useCollapsedSections();
 
   const isActive = (item: NavItem) => {
     if (pathname === item.href) return true;
@@ -135,6 +161,46 @@ const LeftSidebarNav = ({ onNavigate }: LeftSidebarNavProps) => {
     <nav className="flex flex-col flex-1 gap-y-0.5 overflow-y-auto no-scrollbar">
       {/* Main navigation */}
       <div className="space-y-0.5">{mainNavItems.map(renderNavItem)}</div>
+
+      {/* Feeds disclosure — custom feeds + collapsible Channels / Lists groups */}
+      <div className="mx-1 my-1.5 h-px bg-sidebar-border/60" />
+      <div className="space-y-0.5">
+        <SidebarFeedList feeds={customFeeds} selectedId={selectedId} onSelect={selectFeed} />
+
+        <SidebarFeedSection
+          label="Channels"
+          count={isHydrated ? channels.length : undefined}
+          open={isOpen('channels')}
+          onToggle={() => toggle('channels')}
+          footer={
+            <SectionFooterLink
+              href="/channels"
+              label="Pin channels"
+              onNavigate={onNavigate}
+              active={pathname.startsWith('/channels')}
+            />
+          }
+        >
+          <SidebarFeedList feeds={channels} selectedId={selectedId} onSelect={selectFeed} />
+        </SidebarFeedSection>
+
+        <SidebarFeedSection
+          label="Lists"
+          count={isHydrated ? lists.length : undefined}
+          open={isOpen('lists')}
+          onToggle={() => toggle('lists')}
+          footer={
+            <SectionFooterLink
+              href="/lists"
+              label="New list"
+              onNavigate={onNavigate}
+              active={pathname.startsWith('/lists')}
+            />
+          }
+        >
+          <SidebarFeedList feeds={lists} selectedId={selectedId} onSelect={selectFeed} />
+        </SidebarFeedSection>
+      </div>
 
       {/* Spacer */}
       <div className="flex-1" />

--- a/src/common/components/Sidebar/feeds/SidebarFeedList.tsx
+++ b/src/common/components/Sidebar/feeds/SidebarFeedList.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+/**
+ * SidebarFeedList — renders a flat list of `SidebarFeedRow`s for one group
+ * (custom feeds, channels, or lists). When the list is longer than
+ * `initialVisibleCount`, it collapses the tail behind a "Show N more" toggle,
+ * mirroring the approved `lab/` Disclosure variant. Pure presentation.
+ */
+
+import { useState } from 'react';
+import { SidebarFeedRow } from './SidebarFeedRow';
+import type { SidebarFeed } from './types';
+
+export function SidebarFeedList({
+  feeds,
+  selectedId,
+  onSelect,
+  initialVisibleCount = 7,
+}: {
+  feeds: SidebarFeed[];
+  selectedId: string | null;
+  onSelect: (feed: SidebarFeed) => void;
+  initialVisibleCount?: number;
+}) {
+  const [showAll, setShowAll] = useState(false);
+
+  if (feeds.length === 0) return null;
+
+  const canCollapse = feeds.length > initialVisibleCount;
+  const collapsed = canCollapse && !showAll;
+  const visibleFeeds = collapsed ? feeds.slice(0, initialVisibleCount) : feeds;
+
+  // Keep the active feed visible even when it lives in the collapsed tail, so
+  // "where am I?" never disappears behind "Show more".
+  const selectedInTail =
+    collapsed && selectedId != null
+      ? feeds.slice(initialVisibleCount).find((feed) => feed.id === selectedId)
+      : undefined;
+  const moreCount = feeds.length - initialVisibleCount - (selectedInTail ? 1 : 0);
+
+  return (
+    <>
+      {visibleFeeds.map((feed) => (
+        <SidebarFeedRow key={feed.id} feed={feed} isSelected={feed.id === selectedId} onSelect={onSelect} />
+      ))}
+      {selectedInTail && (
+        <SidebarFeedRow key={selectedInTail.id} feed={selectedInTail} isSelected onSelect={onSelect} />
+      )}
+      {canCollapse && (showAll || moreCount > 0) && (
+        <button
+          type="button"
+          onClick={() => setShowAll((v) => !v)}
+          className="px-2 py-1 text-left text-xs font-medium text-sidebar-foreground/45 transition-colors hover:text-sidebar-foreground"
+        >
+          {showAll ? 'Show less' : `Show ${moreCount} more`}
+        </button>
+      )}
+    </>
+  );
+}

--- a/src/common/components/Sidebar/feeds/SidebarFeedRow.tsx
+++ b/src/common/components/Sidebar/feeds/SidebarFeedRow.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+/**
+ * SidebarFeedRow — a single selectable feed row in the left-sidebar "feeds
+ * disclosure" (Direction 01 "Disclosure"). Pure presentation: props in, JSX
+ * out. Ported from the approved `lab/` Disclosure variant (`Row` + `FeedRow` +
+ * `FeedGlyph` + `SidebarKbd`) onto the real `--sidebar-*` design tokens.
+ */
+
+import { Hash } from 'lucide-react';
+import { Kbd } from '@/components/ui/kbd';
+import { cn } from '@/lib/utils';
+import type { SidebarFeed } from './types';
+
+/** Map a canonical key name to its display glyph (e.g. `shift` → `⇧`). */
+function keyGlyph(key: string): string {
+  const map: Record<string, string> = { shift: '⇧', meta: '⌘', ctrl: '⌃' };
+  return map[key.toLowerCase()] ?? key.toUpperCase();
+}
+
+/** Small keyboard hint, dimmed until row hover / selection (matches real nav). */
+function SidebarKbd({ shortcut, active }: { shortcut: string; active?: boolean }) {
+  return (
+    <Kbd
+      className={cn(
+        'h-4 min-w-4 bg-sidebar-accent/60 text-[10px] text-sidebar-foreground/60 transition-opacity',
+        active ? 'opacity-70' : 'opacity-0 group-hover:opacity-60'
+      )}
+    >
+      {shortcut.includes('+')
+        ? shortcut
+            .split('+')
+            .map((k) => keyGlyph(k))
+            .join('')
+        : keyGlyph(shortcut)}
+    </Kbd>
+  );
+}
+
+/** Leading glyph for a feed, by kind (channel avatar / violet # / lucide icon). */
+function FeedGlyph({ feed }: { feed: SidebarFeed }) {
+  if (feed.kind === 'channel') {
+    if (feed.iconUrl) {
+      return (
+        <img
+          src={feed.iconUrl}
+          alt=""
+          className="h-5 w-5 flex-none rounded-md border border-sidebar-border/50 object-cover"
+        />
+      );
+    }
+    // Violet # chip (design rule #4: channels are violet).
+    return (
+      <span className="flex h-5 w-5 flex-none items-center justify-center rounded-md bg-channel/10 text-channel">
+        <Hash className="h-3 w-3" />
+      </span>
+    );
+  }
+
+  const Icon = feed.icon ?? Hash;
+  return (
+    <span className="flex h-5 w-5 flex-none items-center justify-center text-sidebar-foreground/60">
+      <Icon className="h-4 w-4" />
+    </span>
+  );
+}
+
+export function SidebarFeedRow({
+  feed,
+  isSelected,
+  onSelect,
+}: {
+  feed: SidebarFeed;
+  isSelected: boolean;
+  onSelect: (feed: SidebarFeed) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(feed)}
+      title={feed.name}
+      aria-current={isSelected ? 'true' : undefined}
+      className={cn(
+        'group relative flex w-full items-center gap-x-2.5 rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors',
+        isSelected
+          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+          : 'text-sidebar-foreground/80 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground'
+      )}
+    >
+      {isSelected && (
+        <span
+          className={cn(
+            'absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-r-full',
+            feed.kind === 'channel' ? 'bg-channel' : 'bg-sidebar-primary'
+          )}
+        />
+      )}
+      <span className="flex-none">
+        <FeedGlyph feed={feed} />
+      </span>
+      <span className={cn('flex-1 truncate', isSelected && 'font-semibold')}>{feed.name}</span>
+      {feed.kbd && (
+        <span className="ml-auto flex flex-none items-center gap-x-1.5">
+          <SidebarKbd shortcut={feed.kbd} active={isSelected} />
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/common/components/Sidebar/feeds/SidebarFeedSection.tsx
+++ b/src/common/components/Sidebar/feeds/SidebarFeedSection.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * SidebarFeedSection — a collapsible group header (Channels / Lists) plus its
+ * body in the left-sidebar "feeds disclosure". Ported from the approved `lab/`
+ * Disclosure variant (`GroupHeader`): a rotating chevron, an uppercase label,
+ * and an optional dimmed count. Pure presentation — open/close state is owned
+ * by the caller.
+ */
+
+import { ChevronDown } from 'lucide-react';
+import type React from 'react';
+import { cn } from '@/lib/utils';
+
+export function SidebarFeedSection({
+  label,
+  count,
+  open,
+  onToggle,
+  footer,
+  children,
+}: {
+  label: string;
+  count?: number;
+  open: boolean;
+  onToggle: () => void;
+  footer?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="group flex w-full items-center gap-x-1.5 rounded-md px-2 py-1 text-[11px] font-semibold uppercase tracking-wider text-sidebar-foreground/45 transition-colors hover:text-sidebar-foreground/70"
+      >
+        <ChevronDown className={cn('h-3 w-3 flex-none transition-transform duration-150', !open && '-rotate-90')} />
+        <span>{label}</span>
+        {count !== undefined && <span className="text-sidebar-foreground/30">{count}</span>}
+      </button>
+      {open && (
+        <>
+          {children}
+          {footer}
+        </>
+      )}
+    </>
+  );
+}

--- a/src/common/components/Sidebar/feeds/types.ts
+++ b/src/common/components/Sidebar/feeds/types.ts
@@ -1,0 +1,60 @@
+import type { LucideIcon } from 'lucide-react';
+
+/**
+ * Shared contract for the left-sidebar "feeds disclosure" — the collapsible
+ * Channels / Lists groups that surface a user's pinned channels, saved
+ * searches and user lists directly in the rail (Direction 01 "Disclosure").
+ *
+ * `useSidebarFeeds` (data + actions) produces these shapes; the row/section
+ * components consume them. Keep this file dependency-light so both sides can
+ * build against it independently.
+ */
+
+/** What kind of feed a sidebar row points at. */
+export type SidebarFeedKind = 'custom' | 'channel' | 'search' | 'userlist';
+
+/** The two collapsible groups in the disclosure. */
+export type SidebarFeedGroup = 'channels' | 'lists';
+
+/**
+ * A single selectable feed in the sidebar (a custom feed, a pinned channel, a
+ * saved search, or a user/FID list). Presentation-only — no store types leak
+ * through here.
+ */
+export type SidebarFeed = {
+  /**
+   * Stable id, used for selection compare + React keys. Mirrors store identity:
+   *  - custom            → CUSTOM_CHANNELS value ('following' | 'trending')
+   *  - channel           → channel.url
+   *  - search / userlist → list.id (uuid)
+   */
+  id: string;
+  /** Display label (channel/list name, or 'Following' / 'Trending'). */
+  name: string;
+  kind: SidebarFeedKind;
+  /** Leading icon for non-channel feeds. Channels use `iconUrl` or a violet # glyph. */
+  icon?: LucideIcon;
+  /** Channel avatar URL (channels only); falls back to the violet # glyph. */
+  iconUrl?: string;
+  /** Keyboard hint shown on the row, e.g. 'shift+0' (custom feeds only). */
+  kbd?: string;
+};
+
+/** Return shape of `useSidebarFeeds`. */
+export type SidebarFeedsModel = {
+  /** Following + Trending — always shown, in this order. */
+  customFeeds: SidebarFeed[];
+  /** Pinned channels for the active account (store order preserved). */
+  channels: SidebarFeed[];
+  /** Saved searches + user (FID) lists. Excludes auto-interaction lists. */
+  lists: SidebarFeed[];
+  /** Id of the currently active feed (or null) for the selected-row highlight. */
+  selectedId: string | null;
+  /** True once the account + list stores have hydrated (for empty-state gating). */
+  isHydrated: boolean;
+  /**
+   * Switch to a feed: updates the stores, routes to /feeds if needed, fires the
+   * `switch-feed` perf interaction, and closes the mobile drawer (onNavigate).
+   */
+  selectFeed: (feed: SidebarFeed) => void;
+};

--- a/src/common/components/Sidebar/feeds/useCollapsedSections.ts
+++ b/src/common/components/Sidebar/feeds/useCollapsedSections.ts
@@ -1,0 +1,68 @@
+'use client';
+
+/**
+ * useCollapsedSections — persists the open/closed state of the two collapsible
+ * sidebar groups (Channels / Lists) to localStorage. Both default OPEN, since
+ * discoverability is the whole point of the disclosure direction.
+ *
+ * Hydration-safe: the first server + client render always use DEFAULT_STATE, so
+ * the markup matches; the persisted value is applied one tick later in an
+ * effect. All storage access is wrapped so it never throws (SSR, private mode,
+ * quota).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { SidebarFeedGroup } from './types';
+
+const STORAGE_KEY = 'herocast:sidebar:feed-sections';
+
+type SectionState = Record<SidebarFeedGroup, boolean>;
+
+const DEFAULT_STATE: SectionState = { channels: true, lists: true };
+
+function readPersistedState(): SectionState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<SectionState>;
+    return {
+      channels: typeof parsed.channels === 'boolean' ? parsed.channels : DEFAULT_STATE.channels,
+      lists: typeof parsed.lists === 'boolean' ? parsed.lists : DEFAULT_STATE.lists,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function useCollapsedSections(): {
+  isOpen: (g: SidebarFeedGroup) => boolean;
+  toggle: (g: SidebarFeedGroup) => void;
+} {
+  const [state, setState] = useState<SectionState>(DEFAULT_STATE);
+  // Skip persisting the initial DEFAULT_STATE commit so we don't clobber a
+  // stored value before the load effect below has read it.
+  const skipNextPersist = useRef(true);
+
+  useEffect(() => {
+    const persisted = readPersistedState();
+    if (persisted) setState(persisted);
+  }, []);
+
+  useEffect(() => {
+    if (skipNextPersist.current) {
+      skipNextPersist.current = false;
+      return;
+    }
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // Storage unavailable (private mode, quota) — keep in-memory state only.
+    }
+  }, [state]);
+
+  const isOpen = (g: SidebarFeedGroup) => state[g];
+  const toggle = (g: SidebarFeedGroup) => setState((prev) => ({ ...prev, [g]: !prev[g] }));
+
+  return { isOpen, toggle };
+}

--- a/src/common/components/Sidebar/feeds/useSidebarFeeds.ts
+++ b/src/common/components/Sidebar/feeds/useSidebarFeeds.ts
@@ -1,0 +1,104 @@
+import { Home, Search, TrendingUp, Users } from 'lucide-react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
+import { CUSTOM_CHANNELS, useAccountStore } from '@/stores/useAccountStore';
+import { useListStore } from '@/stores/useListStore';
+import { beginInteraction } from '@/stores/usePerformanceStore';
+import type { SidebarFeed, SidebarFeedsModel } from './types';
+
+/**
+ * Following + Trending — static, never changes, so it lives at module scope to
+ * keep the returned `customFeeds` array referentially stable across renders.
+ */
+const CUSTOM_FEEDS: SidebarFeed[] = [
+  { id: CUSTOM_CHANNELS.FOLLOWING, name: 'Following', kind: 'custom', icon: Home, kbd: 'shift+0' },
+  { id: CUSTOM_CHANNELS.TRENDING, name: 'Trending', kind: 'custom', icon: TrendingUp, kbd: 'shift+1' },
+];
+
+/**
+ * Data + actions for the left-sidebar feeds disclosure (Direction 01). Aggregates
+ * the active account's custom feeds, pinned channels and saved searches / user
+ * lists into a presentation-only {@link SidebarFeedsModel}, and exposes a
+ * `selectFeed` action that mirrors the canonical switch-feed semantics
+ * (see `ChannelsOverview.onUpdateChannel` / `useGlobalHotkeys.navigateToList`).
+ *
+ * @param onNavigate Optional callback fired after a selection (e.g. close the
+ *   mobile drawer).
+ */
+export function useSidebarFeeds(onNavigate?: () => void): SidebarFeedsModel {
+  const accountChannels = useAccountStore((s) => s.accounts[s.selectedAccountIdx]?.channels);
+  const selectedChannelUrl = useAccountStore((s) => s.selectedChannelUrl);
+  const setSelectedChannelUrl = useAccountStore((s) => s.setSelectedChannelUrl);
+  const accountIsHydrated = useAccountStore((s) => s.isHydrated);
+
+  const lists = useListStore((s) => s.lists);
+  const selectedListId = useListStore((s) => s.selectedListId);
+  const setSelectedListId = useListStore((s) => s.setSelectedListId);
+  const listIsHydrated = useListStore((s) => s.isHydrated);
+
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const channels = useMemo<SidebarFeed[]>(
+    () =>
+      (accountChannels ?? []).map((channel) => ({
+        id: channel.url,
+        name: channel.name,
+        kind: 'channel',
+        iconUrl: channel.icon_url,
+      })),
+    [accountChannels]
+  );
+
+  // Saved searches first, then user (FID) lists; auto-interaction lists excluded.
+  const sidebarLists = useMemo<SidebarFeed[]>(() => {
+    const searches = lists
+      .filter((list) => list.type === 'search')
+      .map<SidebarFeed>((list) => ({ id: list.id, name: list.name, kind: 'search', icon: Search }));
+    const userLists = lists
+      .filter((list) => list.type === 'fids')
+      .map<SidebarFeed>((list) => ({ id: list.id, name: list.name, kind: 'userlist', icon: Users }));
+    return [...searches, ...userLists];
+  }, [lists]);
+
+  // selectedListId wins; channels and custom feeds compare against selectedChannelUrl.
+  const selectedId = selectedListId ?? selectedChannelUrl ?? null;
+
+  const selectFeed = useCallback(
+    (feed: SidebarFeed) => {
+      const isChannelKind = feed.kind === 'custom' || feed.kind === 'channel';
+      // Re-selecting the already-active feed must not re-stamp the perf
+      // interaction (its content is already painted, so `endInteraction` would
+      // never resolve and the next real switch would inherit a stale start).
+      const isAlreadyActive = isChannelKind
+        ? !selectedListId && selectedChannelUrl === feed.id
+        : selectedListId === feed.id;
+
+      if (!isAlreadyActive) {
+        // Resolved when the new feed's content paints (feeds page content-ready effect)
+        beginInteraction('switch-feed');
+        if (isChannelKind) {
+          setSelectedChannelUrl(feed.id);
+          setSelectedListId(undefined);
+        } else {
+          setSelectedListId(feed.id);
+          setSelectedChannelUrl(null);
+        }
+      }
+      if (pathname !== '/feeds') {
+        router.push('/feeds');
+      }
+      onNavigate?.();
+    },
+    [selectedChannelUrl, selectedListId, setSelectedChannelUrl, setSelectedListId, router, pathname, onNavigate]
+  );
+
+  return {
+    customFeeds: CUSTOM_FEEDS,
+    channels,
+    lists: sidebarLists,
+    selectedId,
+    isHydrated: accountIsHydrated && listIsHydrated,
+    selectFeed,
+  };
+}


### PR DESCRIPTION
## What & why

The left rail only showed flat nav links, so a user's actual **feeds, channels and lists were invisible** until they landed on a page — no indication there was more to browse. We had all of this in the old right sidebar; this brings it back, on the new design system.

Implements **Direction 01 "Disclosure"** from the design exploration: under the primary nav, an inline feeds block with always-on custom feeds plus collapsible **Channels** and **Lists** groups.

## What's in the sidebar now

- **Following / Trending** — always visible, with their `⇧0` / `⇧1` hints
- **Channels (N)** — collapsible group of pinned channels (violet `#` glyph / avatar, per DESIGN.md rule #4), long lists truncated behind "Show N more", footer → `/channels`
- **Lists (N)** — collapsible group of saved searches + user/FID lists (auto-interaction lists excluded — they aren't viewable feeds), footer → `/lists`
- The **active feed is highlighted** (and stays visible even when it's deep in a collapsed list); clicking a row switches the feed and routes to `/feeds`
- Collapse state is **persisted** (localStorage); both groups open by default for discoverability

## Changed

- `src/common/components/Sidebar/feeds/` (new module): `types.ts` (contract), `useSidebarFeeds.ts` (aggregates feeds from `useAccountStore` + `useListStore`; `selectFeed` mirrors existing switch-feed semantics), `SidebarFeed{Row,List,Section}.tsx` + `useCollapsedSections.ts` (token-only presentation, SSR-safe persisted collapse)
- `LeftSidebarNav.tsx` — composes the disclosure; **drops the flat Lists/Channels nav items** (still reachable via active-aware group footers)
- `CLAUDE.md` — update the `inp:switch-feed` instrumentation location

## Preserved

- Hotkeys unchanged: `⇧0`/`⇧1` (Following/Trending), `g›s›N` / `g›l›N` (lists)
- `/channels` and `/lists` pages unchanged and reachable
- Mobile drawer still closes on selection (`onNavigate`)

## Review & verification

- **Independent codex (GPT-5.4) review** flagged 5 issues; all addressed here:
  - selected feed could hide behind "Show N more" → now always kept visible
  - `switch-feed` perf stamp fired on no-op re-selects → guarded
  - `useCollapsedSections` read localStorage in the `useState` initializer (hydration mismatch) → moved to an effect, SSR-safe
  - no active affordance on `/channels` / `/lists` → active-aware footers
  - a11y → added `aria-expanded` / `aria-current`
- `pnpm typecheck` clean; pre-commit biome lint/format clean
- Production components screenshotted (dark + light, expand/collapse, selection) during development

## Test plan

- [ ] On `/feeds`, the sidebar shows Following/Trending + Channels/Lists groups with real data
- [ ] Clicking a channel / list / search switches the feed and highlights the row
- [ ] "Show N more" reveals the rest; collapsing a group persists across reloads
- [ ] `⇧0`/`⇧1` and `g›s›N`/`g›l›N` still switch feeds
- [ ] Mobile: selecting a feed closes the drawer
