### PR TITLE
perf(init): move Phase-1 Supabase round-trips off the critical path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,7 +369,7 @@ Only `warning` and `critical` metrics are sent to PostHog to reduce noise.
 | Feed API | `feed:following` | 1000ms | `useFollowingFeed.ts` |
 | Feed API | `feed:trending` | 1000ms | `useTrendingFeed.ts` |
 | Store Init | `store-init-total` | 4000ms | `initializeStores.ts` |
-| Store Init | `store-init-phase1` | 1000ms | `initializeStores.ts` |
+| Store Init | `store-init-phase1` | 300ms | `initializeStores.ts` |
 | Store Init | `store-init-phase2` | 3000ms | `initializeStores.ts` |
 | INP (perceived) | `inp:like`, `inp:recast` | 100ms | `CastRow/ReactionBar.tsx` |
 | INP (perceived) | `inp:open-notification` | 100ms | `app/(app)/inbox/page.tsx` |

--- a/src/stores/initializeStores.ts
+++ b/src/stores/initializeStores.ts
@@ -28,27 +28,25 @@ export const initializeStoresProgressive = async () => {
   const totalTimingId = startTiming('store-init-total');
   const phase1TimingId = startTiming('store-init-phase1');
 
-  // Phase 1: Critical path - minimal data for basic functionality
+  // Phase 1: Critical path - local only. Rehydrate the account store from
+  // IndexedDB and flip its UI gate so the app shell + skeletons paint
+  // immediately. No Supabase round-trips happen here.
   console.log('Phase 1: Loading critical data 🚀');
-  await Promise.all([
-    useAccountStore.getState().hydrateMinimal(),
-    useDraftStore
-      .getState()
-      .hydrate(), // Drafts are quick to load
-    useNotificationStore
-      .getState()
-      .hydrate(), // Notification states are quick
-  ]);
+  await useAccountStore.getState().hydrateMinimal();
 
-  const phase1Duration = endTiming(phase1TimingId, 1000); // Target: <1s for critical path
+  const phase1Duration = endTiming(phase1TimingId, 300); // Target: <300ms, local rehydrate only
   console.log('Phase 1 complete - UI can be interactive! ✨');
 
-  // Phase 2: Background enhancement - full feature loading
+  // Phase 2: Background enhancement - every blocking Supabase round-trip runs
+  // here, off the critical path. The UI is already interactive and updates
+  // reactively as each store resolves.
   console.log('Phase 2: Loading complete data in background 🌊');
   const phase2TimingId = startTiming('store-init-phase2');
 
   Promise.all([
     useAccountStore.getState().hydrateComplete(),
+    useDraftStore.getState().hydrate(),
+    useNotificationStore.getState().hydrate(),
     useListStore.getState().hydrate(),
     useUserStore.getState().hydrate(),
     useWorkspaceStore.getState().hydrate(),

--- a/src/stores/useAccountStore.ts
+++ b/src/stores/useAccountStore.ts
@@ -460,30 +460,28 @@ const store = (set: StoreSet) => ({
   hydrateMinimal: async () => {
     if (useAccountStore.getState().isHydrated) return;
 
+    // Critical path: wait only for the locally-persisted store (IndexedDB) to
+    // finish rehydrating, then flip the UI gate. No Supabase round-trip here —
+    // warm loads paint instantly from cached accounts, and fresh account data
+    // is fetched off the critical path by hydrateComplete() during Phase 2.
     console.log('hydrating minimal 💧');
-    const accounts = await hydrateAccountsMinimal();
+    try {
+      await useAccountStore.persist.rehydrate();
+    } catch (error) {
+      console.error('Failed to rehydrate persisted account store:', error);
+    }
 
-    useAccountStore.setState({
-      ...useAccountStore.getState(),
-      accounts,
-      isHydrated: true, // Mark as hydrated for basic functionality
-    });
-
+    useAccountStore.setState({ isHydrated: true });
     console.log('done hydrating minimal 💧 basic functionality ready');
   },
   hydrateComplete: async () => {
-    const state = useAccountStore.getState();
-    if (state.accounts.length === 0) return;
-
+    // Background (Phase 2): fetch fresh accounts from Supabase and enrich them
+    // with channels + user metadata. Builds from the Supabase response so cold
+    // loads (nothing cached locally) populate correctly.
     console.log('hydrating complete 🌊');
-    const accounts = await hydrateAccountsComplete(state.accounts);
-    // Note: Removed hydrateChannels() - channels now loaded on-demand for better performance
+    const accounts = await hydrateAccounts();
 
-    useAccountStore.setState({
-      ...state,
-      accounts,
-    });
-
+    useAccountStore.setState({ accounts });
     console.log('done hydrating complete 🌊 full functionality ready');
   },
   updateAccountProperty: (


### PR DESCRIPTION
Closes #740

## Problem

Phase-1 hydration awaited ~3 Supabase round-trips before the account store's `isHydrated` gate flipped, holding the content area behind the `Loading herocast` spinner for ~600ms even though the rest of the app shell (sidebar/header) was already painted:

- `hydrateMinimal()` → `getAccountsForUser` (auth `getUser()` + `accounts` select, ~500ms)
- `useNotificationStore.hydrate()` → `notification_read_states` select
- `useDraftStore.hydrate()` (already fire-and-forget, but bundled into the blocking `Promise.all`)

The content area is gated on `isHydrated` (`src/home/index.tsx`), which only flipped after the accounts round-trip.

## Change

Keep only the truly-blocking minimum (a local IndexedDB read) on the critical path; defer every Supabase round-trip to the existing Phase-2 background fan-out. No new init framework — reuses the existing phased-init + persist/skeleton patterns.

- **`useAccountStore.hydrateMinimal()`** — awaits only `persist.rehydrate()` (local IndexedDB), then flips `isHydrated`. No Supabase. Warm loads paint instantly from cached accounts; because we await the local rehydrate first, returning users don't flash an empty/"create account" state.
- **`useAccountStore.hydrateComplete()`** — now fetches fresh accounts (minimal + channels + user metadata) via the canonical `hydrateAccounts()`, so it is self-sufficient on cold loads (empty cache) instead of relying on `hydrateMinimal` having pre-populated state.
- **`initializeStoresProgressive()`** — Phase-1 is now just `hydrateMinimal()`; drafts + notifications move into the Phase-2 background `Promise.all`. The 3 Supabase round-trips (accounts, notifications, drafts) all run off the critical path; the UI updates reactively (zustand subscriptions) as each resolves.
- **Perf threshold** — `store-init-phase1` tightened 1000ms → 300ms (it is now a local-only step), with the CLAUDE.md instrumentation table updated to match.

## Expected impact

`store-init-phase1` drops from ~500-600ms (bound by the accounts round-trip) to a single local IndexedDB read + JSON.parse (tens of ms), well under the 300ms threshold. The content gate (`!isHydrated`) opens almost immediately, so time-to-interactive for the content area is no longer bound by Supabase.

## Scope note

Changes are confined to the hydration/init path (`initializeStores.ts` + the two account-store hydrate methods) to avoid stepping on #741, which will also touch `useAccountStore.ts`. `home/index.tsx` and `useInitializeStores.ts` are unchanged — they benefit automatically because the gate flips fast and the shell already renders outside the gate.

## Verification

- `pnpm run typecheck` — pass (validates the `persist.rehydrate()` typing)
- `pnpm run lint` (biome) — pass
- `pnpm test` — 128/128 pass
- `pnpm run build` — pass with Supabase env vars present. In a bare sandbox (no `NEXT_PUBLIC_SUPABASE_*`) prerendering throws by design from the Supabase client factory; this reproduces on any branch and is unrelated to this change (the edits add no module-level client creation).

I could not exercise the live client-side hydration / `window.__perfSummary()` in this headless sandbox (no browser, no real Supabase credentials), so the phase-1 timing above is reasoned from the code rather than measured at runtime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERHzUXZXcaGGpE1XWxbWn2)_