### PR TITLE
feat(feed): optimistic feed insertion on publish

### DIFF
--- a/app/(app)/feeds/page.tsx
+++ b/app/(app)/feeds/page.tsx
@@ -8,6 +8,7 @@ import { Key } from 'ts-key-enum';
 import { CompactCastRow } from '@/common/components/CastRow/CompactCastRow';
 import { CreateAccountPage } from '@/common/components/CreateAccountPage';
 import { NewCastsPill } from '@/common/components/Feed/NewCastsPill';
+import { countNewCastsAboveAcknowledged } from '@/common/components/Feed/newCastsCount';
 import { PreviewPane } from '@/common/components/Feed/PreviewPane';
 import { SplitPaneShell } from '@/common/components/Feed/SplitPaneShell';
 import RecommendedProfilesCard from '@/common/components/RecommendedProfilesCard';
@@ -236,17 +237,14 @@ export default function Feeds() {
     }
   }, [feedContentReady, feedKey]);
 
-  // Compute the count of "new" casts above the user's last acknowledged top.
-  // `acknowledgedFirstHash` is null on the very first render (no pill yet),
-  // and is reset to null on feed switch. When the acknowledged hash is no
-  // longer present in the array (e.g. a full server-side refresh that drops
-  // the previous head), treat as 0 — the conservative path avoids surprising
-  // the user with a giant "N new casts" count after the feed got nuked.
-  let newCastsCount = 0;
-  if (acknowledgedFirstHash !== null && casts.length > 0 && casts[0]?.hash !== acknowledgedFirstHash) {
-    const idx = casts.findIndex((c) => c.hash === acknowledgedFirstHash);
-    newCastsCount = idx === -1 ? 0 : idx;
-  }
+  // Count of "new" casts above the user's last acknowledged top, used to drive
+  // the NewCastsPill. Excludes the viewer's own optimistically-inserted casts
+  // (#739) — see countNewCastsAboveAcknowledged for the full rationale.
+  const newCastsCount = countNewCastsAboveAcknowledged(
+    casts,
+    acknowledgedFirstHash,
+    Number(account?.platformAccountId)
+  );
 
   // On desktop the preview pane already shows the selected cast, so click /
   // Enter / `o` should just update selection. Below the lg breakpoint there

--- a/src/common/components/Feed/__tests__/newCastsCount.test.ts
+++ b/src/common/components/Feed/__tests__/newCastsCount.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@jest/globals';
+import type { FarcasterCast } from '@/common/types/farcaster';
+import { countNewCastsAboveAcknowledged } from '../newCastsCount';
+
+const VIEWER_FID = 3;
+
+const cast = (hash: string, fid: number): Pick<FarcasterCast, 'hash' | 'author'> =>
+  ({ hash, author: { fid } }) as Pick<FarcasterCast, 'hash' | 'author'>;
+
+describe('countNewCastsAboveAcknowledged', () => {
+  it('returns 0 before anything is acknowledged', () => {
+    expect(countNewCastsAboveAcknowledged([cast('0x1', 9)], null, VIEWER_FID)).toBe(0);
+  });
+
+  it('returns 0 when the head is still the acknowledged cast', () => {
+    const casts = [cast('0x1', 9), cast('0x2', 9)];
+    expect(countNewCastsAboveAcknowledged(casts, '0x1', VIEWER_FID)).toBe(0);
+  });
+
+  it('counts casts above the acknowledged head (steady state, no own casts)', () => {
+    const casts = [cast('0xa', 9), cast('0xb', 9), cast('0xOLD', 9)];
+    expect(countNewCastsAboveAcknowledged(casts, '0xOLD', VIEWER_FID)).toBe(2);
+  });
+
+  it("excludes the viewer's own optimistically-inserted cast", () => {
+    // Own cast prepended on publish; the acknowledged head is right below it.
+    const casts = [cast('0xMINE', VIEWER_FID), cast('0xOLD', 9)];
+    expect(countNewCastsAboveAcknowledged(casts, '0xOLD', VIEWER_FID)).toBe(0);
+  });
+
+  it("counts others' new casts but not the viewer's own mixed in", () => {
+    const casts = [cast('0xMINE', VIEWER_FID), cast('0xOTHER1', 9), cast('0xOTHER2', 7), cast('0xOLD', 9)];
+    expect(countNewCastsAboveAcknowledged(casts, '0xOLD', VIEWER_FID)).toBe(2);
+  });
+
+  it('returns 0 when the acknowledged cast has been pruned from the list', () => {
+    const casts = [cast('0xa', 9), cast('0xb', 9)];
+    expect(countNewCastsAboveAcknowledged(casts, '0xGONE', VIEWER_FID)).toBe(0);
+  });
+});

--- a/src/common/components/Feed/newCastsCount.ts
+++ b/src/common/components/Feed/newCastsCount.ts
@@ -1,0 +1,28 @@
+import type { FarcasterCast } from '@/common/types/farcaster';
+
+/**
+ * Count the "new" casts sitting above the user's last acknowledged top cast —
+ * i.e. how many to surface in the NewCastsPill.
+ *
+ * The viewer's own casts are excluded: a cast you just published is
+ * optimistically prepended to the feed (#739) but isn't "new" content to scroll
+ * up for, so it must not inflate the pill. In the steady state (no own casts
+ * present) the filter is a no-op, so the count is unchanged.
+ *
+ * Returns 0 when there's nothing acknowledged yet, when the head is unchanged,
+ * or when the acknowledged cast has been pruned from the list — the conservative
+ * path avoids a surprise count after a feed refresh drops the previous head.
+ */
+export function countNewCastsAboveAcknowledged(
+  casts: Pick<FarcasterCast, 'hash' | 'author'>[],
+  acknowledgedHash: string | null,
+  viewerFid: number
+): number {
+  if (acknowledgedHash === null || casts.length === 0) return 0;
+  if (casts[0]?.hash === acknowledgedHash) return 0;
+
+  const idx = casts.findIndex((c) => c.hash === acknowledgedHash);
+  if (idx <= 0) return 0;
+
+  return casts.slice(0, idx).filter((c) => c.author?.fid !== viewerFid).length;
+}

--- a/src/lib/__tests__/optimisticPublish.test.ts
+++ b/src/lib/__tests__/optimisticPublish.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from '@jest/globals';
+import { QueryClient } from '@tanstack/react-query';
+import type { DraftType } from '@/common/constants/farcaster';
+import { DraftStatus } from '@/common/constants/farcaster';
+import type { FarcasterCast, FarcasterUser } from '@/common/types/farcaster';
+import { buildOptimisticCast, insertPublishedCastIntoFeeds, prependCastToFeedData } from '@/lib/optimisticPublish';
+import { queryKeys } from '@/lib/queryKeys';
+import type { AccountObjectType } from '@/stores/useAccountStore';
+
+const FID = '3';
+
+const author = { fid: 3, username: 'dwr', display_name: 'Dan', pfp_url: 'x' } as unknown as FarcasterUser;
+const account = { platformAccountId: FID, user: author } as unknown as AccountObjectType;
+
+const makeDraft = (overrides: Partial<DraftType> = {}): DraftType => ({
+  id: 'draft-1',
+  text: 'hello world',
+  status: DraftStatus.published,
+  createdAt: Date.now(),
+  ...overrides,
+});
+
+const existingCast = (hash: string): FarcasterCast =>
+  ({ object: 'cast', hash, text: 'old', author, timestamp: '2024-01-01T00:00:00Z' }) as FarcasterCast;
+
+const feedData = (...hashes: string[]) => ({ pages: [{ casts: hashes.map(existingCast) }], pageParams: [undefined] });
+
+describe('buildOptimisticCast', () => {
+  it('builds a renderable cast from the draft + account + hash', () => {
+    const cast = buildOptimisticCast(makeDraft({ text: 'gm' }), account, '0xabc');
+    expect(cast).toMatchObject({ object: 'cast', hash: '0xabc', text: 'gm', author });
+    expect(cast?.reactions).toEqual({ likes_count: 0, recasts_count: 0, likes: [], recasts: [] });
+    expect(cast?.replies).toEqual({ count: 0 });
+    expect(typeof cast?.timestamp).toBe('string');
+  });
+
+  it('maps url and quote-cast embeds to the cast embed shape', () => {
+    const cast = buildOptimisticCast(
+      makeDraft({ embeds: [{ url: 'https://x.com' }, { castId: { fid: 9, hash: '0xdef' } }] }),
+      account,
+      '0xabc'
+    );
+    expect(cast?.embeds).toEqual([{ url: 'https://x.com' }, { cast_id: { fid: 9, hash: '0xdef' } }]);
+  });
+
+  it('returns null when the account has no resolved user', () => {
+    const noUser = { platformAccountId: FID } as unknown as AccountObjectType;
+    expect(buildOptimisticCast(makeDraft(), noUser, '0xabc')).toBeNull();
+  });
+});
+
+describe('prependCastToFeedData', () => {
+  it('prepends the cast to the first page', () => {
+    const result = prependCastToFeedData(feedData('0x1', '0x2'), existingCast('0xnew'));
+    expect(result?.pages?.[0].casts.map((c) => c.hash)).toEqual(['0xnew', '0x1', '0x2']);
+  });
+
+  it('is a no-op when the cast hash is already present (dedup)', () => {
+    const data = feedData('0x1', '0x2');
+    expect(prependCastToFeedData(data, existingCast('0x2'))).toBe(data);
+  });
+
+  it('leaves empty / unloaded caches untouched', () => {
+    expect(prependCastToFeedData(undefined, existingCast('0xnew'))).toBeUndefined();
+    const empty = { pages: [] };
+    expect(prependCastToFeedData(empty, existingCast('0xnew'))).toBe(empty);
+  });
+});
+
+describe('insertPublishedCastIntoFeeds', () => {
+  const followingKey = queryKeys.feeds.following(FID, { limit: 15 });
+
+  it('prepends into the loaded following feed', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(followingKey, feedData('0x1'));
+
+    insertPublishedCastIntoFeeds(qc, makeDraft(), account, '0xnew');
+
+    const data = qc.getQueryData(followingKey) as ReturnType<typeof feedData>;
+    expect(data.pages[0].casts.map((c) => c.hash)).toEqual(['0xnew', '0x1']);
+  });
+
+  it('also prepends into the channel feed when posted to a channel', () => {
+    const qc = new QueryClient();
+    const parentUrl = 'https://channel/dev';
+    const channelKey = queryKeys.feeds.channel(parentUrl, FID, { limit: 15 });
+    qc.setQueryData(followingKey, feedData('0x1'));
+    qc.setQueryData(channelKey, feedData('0x9'));
+
+    insertPublishedCastIntoFeeds(qc, makeDraft({ parentUrl }), account, '0xnew');
+
+    expect((qc.getQueryData(followingKey) as ReturnType<typeof feedData>).pages[0].casts[0].hash).toBe('0xnew');
+    expect((qc.getQueryData(channelKey) as ReturnType<typeof feedData>).pages[0].casts[0].hash).toBe('0xnew');
+  });
+
+  it('skips replies (parentCastId set)', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(followingKey, feedData('0x1'));
+
+    insertPublishedCastIntoFeeds(qc, makeDraft({ parentCastId: { fid: 9, hash: '0xparent' } }), account, '0xnew');
+
+    expect((qc.getQueryData(followingKey) as ReturnType<typeof feedData>).pages[0].casts.map((c) => c.hash)).toEqual([
+      '0x1',
+    ]);
+  });
+
+  it('does not duplicate when a refetch already brought the cast back', () => {
+    const qc = new QueryClient();
+    qc.setQueryData(followingKey, feedData('0xnew', '0x1'));
+
+    insertPublishedCastIntoFeeds(qc, makeDraft(), account, '0xnew');
+
+    expect((qc.getQueryData(followingKey) as ReturnType<typeof feedData>).pages[0].casts.map((c) => c.hash)).toEqual([
+      '0xnew',
+      '0x1',
+    ]);
+  });
+});

--- a/src/lib/optimisticPublish.ts
+++ b/src/lib/optimisticPublish.ts
@@ -1,0 +1,93 @@
+import type { QueryClient } from '@tanstack/react-query';
+import type { DraftType } from '@/common/constants/farcaster';
+import type { CastEmbed, FarcasterCast } from '@/common/types/farcaster';
+import { queryKeys } from '@/lib/queryKeys';
+import type { AccountObjectType } from '@/stores/useAccountStore';
+
+/**
+ * Optimistic feed insertion on publish (#739).
+ *
+ * After a cast publishes successfully we prepend it into the relevant feed
+ * query caches so it appears immediately instead of waiting for a manual
+ * refresh. This reuses the same cache-mutation shape as the cast reaction
+ * optimistic updates (`src/hooks/mutations/useCastActions.ts`): map over the
+ * infinite-query `pages` and rewrite `casts`. The next refetch reconciles the
+ * cache with the server response (dedup is by hash, so no duplicate appears).
+ *
+ * No rollback is needed here — unlike reactions, we insert only after the
+ * publish has already succeeded, so there is nothing to undo.
+ */
+
+type FeedPageData = { pages?: Array<{ casts: FarcasterCast[] }> };
+
+/**
+ * Build a minimal FarcasterCast for a just-published draft. Returns null when
+ * the account has no resolved user profile (we'd render a broken row), in
+ * which case the caller skips the optimistic insert and lets refetch handle it.
+ */
+export function buildOptimisticCast(draft: DraftType, account: AccountObjectType, hash: string): FarcasterCast | null {
+  const author = account.user;
+  if (!author?.fid) return null;
+
+  const embeds: CastEmbed[] = (draft.embeds ?? []).map((embed) =>
+    'castId' in embed ? { cast_id: embed.castId } : { url: embed.url }
+  );
+
+  return {
+    object: 'cast',
+    hash,
+    parent_hash: draft.parentCastId?.hash ?? null,
+    parent_url: draft.parentUrl,
+    author,
+    text: draft.text ?? '',
+    timestamp: new Date().toISOString(),
+    embeds,
+    reactions: { likes_count: 0, recasts_count: 0, likes: [], recasts: [] },
+    replies: { count: 0 },
+  };
+}
+
+/**
+ * Pure helper: prepend `cast` to the first page of an infinite-feed cache,
+ * deduped by hash. Returns the data unchanged when the feed is empty/unloaded
+ * or already contains the cast.
+ */
+export function prependCastToFeedData(
+  oldData: FeedPageData | undefined,
+  cast: FarcasterCast
+): FeedPageData | undefined {
+  if (!oldData?.pages || oldData.pages.length === 0) return oldData;
+  if (oldData.pages.some((page) => page.casts.some((c) => c.hash === cast.hash))) return oldData;
+
+  const [firstPage, ...rest] = oldData.pages;
+  return { ...oldData, pages: [{ ...firstPage, casts: [cast, ...firstPage.casts] }, ...rest] };
+}
+
+/**
+ * Prepend a freshly published cast into the active following feed cache (and
+ * the channel feed cache when posted to a channel). `setQueriesData` only
+ * touches feeds the user has already loaded, so this is a no-op for feeds that
+ * aren't mounted. Replies are skipped — they belong in their thread, not at the
+ * top of a feed.
+ */
+export function insertPublishedCastIntoFeeds(
+  queryClient: QueryClient,
+  draft: DraftType,
+  account: AccountObjectType,
+  hash: string
+): void {
+  if (draft.parentCastId) return;
+
+  const fid = account.platformAccountId;
+  if (!fid) return;
+
+  const cast = buildOptimisticCast(draft, account, hash);
+  if (!cast) return;
+
+  const update = (oldData: FeedPageData | undefined) => prependCastToFeedData(oldData, cast);
+
+  queryClient.setQueriesData({ queryKey: queryKeys.feeds.followingPrefix(fid), exact: false }, update);
+  if (draft.parentUrl) {
+    queryClient.setQueriesData({ queryKey: queryKeys.feeds.channelPrefix(draft.parentUrl, fid), exact: false }, update);
+  }
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -16,8 +16,12 @@ export const queryKeys = {
   feeds: {
     all: ['feeds'] as const,
     trending: (options?: { cursor?: string; limit?: number }) => ['feeds', 'trending', options ?? {}] as const,
+    // Prefix (sans options) for matching every `{limit}`/`{cursor}` variant of a
+    // feed query with `exact: false` — e.g. optimistic cache writes on publish.
+    followingPrefix: (fid: string) => ['feeds', 'following', fid] as const,
     following: (fid: string, options?: { cursor?: string; limit?: number }) =>
       ['feeds', 'following', fid, options ?? {}] as const,
+    channelPrefix: (parentUrl: string, fid: string) => ['feeds', 'channel', parentUrl, fid] as const,
     channel: (parentUrl: string, fid: string, options?: { cursor?: string; limit?: number }) =>
       ['feeds', 'channel', parentUrl, fid, options ?? {}] as const,
     list: (listId: string, options?: { cursor?: string; limit?: number; contentsHash?: string }) =>

--- a/src/stores/useDraftStore.ts
+++ b/src/stores/useDraftStore.ts
@@ -26,6 +26,8 @@ import {
   toastSuccessCastScheduled,
 } from '@/common/helpers/toast';
 import type { FarcasterEmbed } from '@/common/types/embeds';
+import { insertPublishedCastIntoFeeds } from '@/lib/optimisticPublish';
+import { getQueryClient } from '@/lib/queryClient';
 import { type AccountObjectType, useAccountStore } from './useAccountStore';
 import { CastModalView, useNavigationStore } from './useNavigationStore';
 
@@ -394,6 +396,10 @@ const store = (set: StoreSet) => ({
           };
         }
       });
+
+      // Optimistically surface the cast in the feed immediately (#739) instead
+      // of waiting for the next refetch / manual refresh.
+      insertPublishedCastIntoFeeds(getQueryClient(), draft, account, hash);
 
       toastSuccessCastPublished(draft.text);
       onPost?.();


### PR DESCRIPTION
Closes #739.

## Problem
After publishing a cast it didn't appear in the feed until a manual refresh — the compose modal closed optimistically but the feed query cache was never updated.

## Approach
On publish **success**, prepend the new cast into the active **following** feed cache (and the **channel** feed cache when posted to a channel) via `setQueryData`. The next refetch reconciles the cache with the server; dedup is by hash, so no duplicate appears.

This reuses the cache-mutation shape already established by the cast-reaction optimistic updates in `src/hooks/mutations/useCastActions.ts` (map over the infinite-query `pages`, rewrite `casts`) rather than inventing a new mechanism. No rollback is needed here — unlike reactions, we insert only *after* the publish has already succeeded, so there's nothing to undo.

The insert lives in the store's publish path (`publishDraftById`), a single point that covers the compose modal, the reply modal, and a thread's root post. Replies (casts with a `parentCastId`) are skipped — they belong in their thread, not at the top of a feed.

## Changes
- **`src/lib/queryKeys.ts`** — add `feeds.followingPrefix(fid)` / `feeds.channelPrefix(parentUrl, fid)` (key prefixes without the `{options}` element) so every `{limit}`/`{cursor}` variant matches with `exact: false`. Mirrors the existing `profiles.byFidPrefix` / `bulkPrefix` convention.
- **`src/lib/optimisticPublish.ts`** (new) — `buildOptimisticCast` (draft + account + hash → minimal `FarcasterCast`), a pure `prependCastToFeedData` (dedup by hash), and `insertPublishedCastIntoFeeds` (targets following + optional channel; skips replies).
- **`src/stores/useDraftStore.ts`** — call `insertPublishedCastIntoFeeds(...)` in `publishDraftById` right after the success state update.
- **`src/lib/__tests__/optimisticPublish.test.ts`** (new) — 10 unit tests covering build, prepend, dedup, following/channel targeting, and reply-skip (exercised against a real `QueryClient`).

## Target metric
Own cast visible in feed **< 200ms** after publish succeeds, no manual refresh. The `setQueryData` → re-render → paint is effectively instant; the modal already closes optimistically (`trackInteractionToPaint('publish')`).

## Verification
- `pnpm run lint` (Biome) — clean (470 files)
- `pnpm test` — 138/138 pass (incl. the 10 new tests)
- `tsc --noEmit` — clean
- `pnpm run build` — succeeds when Supabase env vars are present. A bare build in this environment fails prerendering `/auth/auth-code-error` because the sandbox has no `NEXT_PUBLIC_SUPABASE_*` vars (the Supabase client throws during SSR); that's pre-existing and unrelated to this change — confirmed by a clean build once placeholder env vars are supplied.

I was **not** able to run the app to publish a real cast end-to-end (requires live Neynar/Supabase credentials and an authenticated Farcaster signer). The dedup-on-refetch behavior is covered by the unit tests instead.

https://claude.ai/code/session_01VscjJNbsFDMrkeP9Md3trJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VscjJNbsFDMrkeP9Md3trJ)_