### PR TITLE
Fix untappable top menu/buttons in iOS standalone PWA

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -275,3 +275,23 @@
     --density-pad-y: 12px;
   }
 }
+
+@layer utilities {
+  /*
+   * iOS standalone PWA safe-area helpers.
+   *
+   * Launched from the Home Screen we use `viewport-fit=cover` with a
+   * `black-translucent` status bar (see `app/layout.tsx`), so the web view
+   * extends under the status bar / notch. Without padding, top-of-screen
+   * controls (hamburger menu, header actions) sit beneath the status bar and
+   * cannot be tapped — iOS routes those touches to the status bar, not the
+   * page. `env(safe-area-inset-*)` resolves to 0 on platforms without insets,
+   * so these utilities are no-ops on web and desktop.
+   */
+  .pt-safe {
+    padding-top: env(safe-area-inset-top);
+  }
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}

--- a/src/home/index.tsx
+++ b/src/home/index.tsx
@@ -436,7 +436,7 @@ const Home = ({ children }: { children: React.ReactNode }) => {
                 >
                   <Dialog.Panel className="relative mr-2 flex w-full max-w-xs flex-1">
                     {/* Mobile Sidebar */}
-                    <div className="flex grow flex-col flex-1 gap-y-3 overflow-y-auto bg-sidebar text-sidebar-foreground px-3 no-scrollbar">
+                    <div className="flex grow flex-col flex-1 gap-y-3 overflow-y-auto bg-sidebar text-sidebar-foreground px-3 pt-safe no-scrollbar">
                       <div className="flex h-14 shrink-0 items-center">
                         <Link href="/post" className="flex items-center hover:cursor-pointer">
                           <h2 className="text-xl font-bold leading-7 text-foreground sm:truncate sm:tracking-tight">
@@ -455,7 +455,7 @@ const Home = ({ children }: { children: React.ReactNode }) => {
                       <LeftSidebarNav onNavigate={() => setSidebarOpen(false)} />
                       {isReadOnlyUser && renderUpgradeCard()}
                       {!isReadOnlyUser && !hasFinishedOnboarding && isHydrated && renderFinishOnboardingCard()}
-                      <div className="mt-auto py-3">
+                      <div className="mt-auto py-3 pb-safe">
                         <AccountSwitcher />
                       </div>
                     </div>
@@ -480,7 +480,7 @@ const Home = ({ children }: { children: React.ReactNode }) => {
                 )}
               >
                 {/* Sidebar component */}
-                <div className="flex grow flex-col flex-1 gap-y-3 overflow-y-auto bg-sidebar text-sidebar-foreground px-3 no-scrollbar">
+                <div className="flex grow flex-col flex-1 gap-y-3 overflow-y-auto bg-sidebar text-sidebar-foreground px-3 pt-safe no-scrollbar">
                   <div className="flex h-14 shrink-0 items-center">
                     <Link href="/post" className="flex items-center hover:cursor-pointer">
                       <h2 className="text-xl font-bold leading-7 text-foreground sm:truncate sm:tracking-tight">
@@ -492,7 +492,7 @@ const Home = ({ children }: { children: React.ReactNode }) => {
                   <LeftSidebarNav />
                   {isReadOnlyUser && renderUpgradeCard()}
                   {!isReadOnlyUser && !hasFinishedOnboarding && isHydrated && renderFinishOnboardingCard()}
-                  <div className="mt-auto py-3">
+                  <div className="mt-auto py-3 pb-safe">
                     <AccountSwitcher />
                   </div>
                 </div>
@@ -501,7 +501,7 @@ const Home = ({ children }: { children: React.ReactNode }) => {
                 <div className="flex-1 h-full flex flex-col min-w-0 min-h-0">
                   {/* Header */}
                   {!hideTitlebar && (title || headerActions) && (
-                    <div className="flex h-16 flex-shrink-0 items-center gap-x-6 md:gap-x-0 border-b border-border bg-background px-4 sm:px-6 md:px-4 min-w-0">
+                    <div className="flex min-h-[4rem] pt-safe flex-shrink-0 items-center gap-x-6 md:gap-x-0 border-b border-border bg-background px-4 sm:px-6 md:px-4 min-w-0">
                       <button
                         type="button"
                         className="-m-2.5 p-2.5 text-foreground lg:hidden flex-shrink-0"


### PR DESCRIPTION
When herocast is launched from the iOS Home Screen, the web view runs with
viewport-fit=cover and a black-translucent status bar, so the layout extends
under the status bar/notch. The top header (hamburger menu, title, header
actions) and the sidebar logo/close button sat beneath the status bar, where
iOS routes touches to the status bar instead of the page — making them
impossible to tap.

Add `pt-safe`/`pb-safe` safe-area utilities backed by `env(safe-area-inset-*)`
and apply them to the header and both sidebars (plus bottom padding for the
account switcher to clear the home indicator). The header now uses min-height
so the inset padding grows the bar instead of squishing its contents. The
utilities resolve to 0 on web/desktop, so nothing changes outside iOS PWA.