### PR TITLE
fix(provider): resolve Hypersnap onboarding empty feeds

### DIFF
--- a/app/(app)/feeds/page.tsx
+++ b/app/(app)/feeds/page.tsx
@@ -724,8 +724,17 @@ export default function Feeds() {
               </CardFooter>
             </Card>
           </div>
-          <TrendingChannelsCard />
-          <RecommendedProfilesCard />
+          {/* Discovery prompts ("Follow more profiles…", trending channels) are onboarding
+              guidance for the home/following feed — a thin following graph is why it's empty.
+              On a specific channel, list, or search, an empty result means that source has no
+              casts (or isn't indexed), not that the user follows too few people, so suppress
+              them there to avoid the off-context "Follow more profiles" prompt. */}
+          {isFollowingFeed && (
+            <>
+              <TrendingChannelsCard />
+              <RecommendedProfilesCard />
+            </>
+          )}
         </div>
       )
     );

--- a/src/hooks/queries/useCastSearch.ts
+++ b/src/hooks/queries/useCastSearch.ts
@@ -97,6 +97,13 @@ export function useCastSearchInfinite(
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.results.length < lastPage.limitUsed) return undefined;
 
+      // Stop when a page adds no new cast hashes. Guards against providers that ignore `offset`
+      // and return a single fixed page (hypersnap /cast/search has no pagination): without this,
+      // a full first page would refetch identical results forever. Neynar's offset pages always
+      // bring new hashes, so this never short-circuits real pagination.
+      const priorHashes = new Set(allPages.slice(0, -1).flatMap((page) => page.results.map((r) => r.hash)));
+      if (!lastPage.results.some((r) => !priorHashes.has(r.hash))) return undefined;
+
       const nextOffset = allPages.reduce((sum, page) => sum + page.results.length, 0);
       return { offset: nextOffset, limit };
     },

--- a/src/lib/farcaster/providers/__tests__/getProvider.test.ts
+++ b/src/lib/farcaster/providers/__tests__/getProvider.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+// Controllable stand-in for the user settings store's resolved provider. Flipping this mid-test
+// simulates hydrate() replacing the synchronous localStorage seed with the authoritative
+// Supabase preference.
+let currentProvider = 'neynar';
+
+jest.mock('@/stores/useUserSettingsStore', () => ({
+  useUserSettingsStore: Object.assign(() => currentProvider, {
+    getState: () => ({ farcasterProvider: currentProvider }),
+  }),
+}));
+
+jest.mock('@/lib/queryClient', () => ({
+  getQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+// Providers pull in the perf store transitively; stub it so we don't drag in zustand/posthog.
+jest.mock('@/stores/usePerformanceStore', () => ({
+  measureAsync: <T>(_name: string, fn: () => Promise<T>) => fn(),
+  usePerformanceStore: { getState: () => ({ addMetric: jest.fn() }) },
+}));
+
+describe('getProvider singleton', () => {
+  beforeEach(() => {
+    currentProvider = 'neynar';
+    // getProviderType() short-circuits to 'neynar' when window is undefined (SSR guard); the node
+    // test env has no window, so define one to exercise the client path.
+    (globalThis as { window?: unknown }).window = (globalThis as { window?: unknown }).window ?? {};
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('rebuilds the singleton when the resolved provider type changes, instead of pinning the first read', async () => {
+    const { getProvider } = await import('../index');
+
+    expect(getProvider().type).toBe('neynar');
+
+    // hydrate() resolves the authoritative provider after the initial seed.
+    currentProvider = 'hypersnap';
+    expect(getProvider().type).toBe('hypersnap');
+
+    // Not a one-way latch — it tracks the resolved type in both directions.
+    currentProvider = 'neynar';
+    expect(getProvider().type).toBe('neynar');
+  });
+
+  it('returns a stable instance while the provider type is unchanged', async () => {
+    const { getProvider } = await import('../index');
+
+    currentProvider = 'hypersnap';
+    const first = getProvider();
+    const second = getProvider();
+
+    expect(first).toBe(second);
+  });
+});

--- a/src/lib/farcaster/providers/__tests__/hypersnap.test.ts
+++ b/src/lib/farcaster/providers/__tests__/hypersnap.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { createHypersnapProvider } from '../hypersnap';
+import { UnsupportedProviderFeatureError } from '../types';
 
 // Avoid pulling in zustand/posthog via the real performance store — just run the work.
 jest.mock('@/stores/usePerformanceStore', () => ({
@@ -219,6 +220,36 @@ describe('createHypersnapProvider — new provider methods', () => {
       const users = await provider.getBestFriends({ fid: 3, limit: 5 });
 
       expect(users.map((u) => u.fid)).toEqual([1, 2]);
+    });
+  });
+
+  describe('getChannelFeed', () => {
+    it('always defers to the fallback provider (haatz feed/channels is unindexed for most channels)', () => {
+      // Throws synchronously so the fallback proxy routes the whole query to Neynar — no upstream call.
+      expect(() => provider.getChannelFeed({ parentUrl: 'https://warpcast.com/~/channel/degen' })).toThrow(
+        UnsupportedProviderFeatureError
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('searchCasts', () => {
+    it('runs a plain keyword search against cast/search when only interval/viewerFid are set', async () => {
+      mockJson({ result: { casts: [{ hash: '0xc1', author: { fid: 5 }, text: 'gm', timestamp: 't1' }] } });
+
+      const res = await provider.searchCasts({ q: 'ethereum', limit: 10, filters: { interval: 'd7', viewerFid: '3' } });
+
+      expect(res.results.map((r) => r.hash)).toEqual(['0xc1']);
+      const url = fetchMock.mock.calls[0][0] as string;
+      expect(new URL(url, 'http://x').pathname).toContain('cast/search');
+      expect(new URL(url, 'http://x').searchParams.get('q')).toBe('ethereum');
+    });
+
+    it('falls back (throws unsupported) when a match-narrowing filter is present', async () => {
+      await expect(
+        provider.searchCasts({ q: 'ethereum', limit: 10, filters: { channelId: 'degen', interval: 'd7' } })
+      ).rejects.toBeInstanceOf(UnsupportedProviderFeatureError);
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/farcaster/providers/hypersnap.ts
+++ b/src/lib/farcaster/providers/hypersnap.ts
@@ -81,17 +81,6 @@ function unsupported(method: string): never {
   throw new UnsupportedFeatureError('hypersnap', method);
 }
 
-/** Extract channel ID from a Warpcast channel URL like https://warpcast.com/~/channel/degen */
-function channelIdFromUrl(parentUrl: string): string {
-  try {
-    const pathname = new URL(parentUrl).pathname.replace(/\/+$/, '');
-    return pathname.split('/').pop() || parentUrl;
-  } catch {
-    // Not a valid URL, treat as raw channel ID
-    return parentUrl;
-  }
-}
-
 export function createHypersnapProvider(): FarcasterProvider {
   return {
     type: 'hypersnap',
@@ -166,9 +155,15 @@ export function createHypersnapProvider(): FarcasterProvider {
       return unsupported('getTrendingFeed');
     },
 
-    async getChannelFeed({ parentUrl, limit = 15, cursor, signal }) {
-      const channelId = channelIdFromUrl(parentUrl);
-      return fetchJson<FeedResponse>(buildUrl('feed/channels', { channel_ids: channelId, limit, cursor }), signal);
+    getChannelFeed() {
+      // haatz feed/channels only returns casts indexed under the warpcast.com/~/channel/<id>
+      // parent_url. Token-gated (chain://) channels, farcaster.xyz channels, and most large
+      // legacy channels (degen, base, founders, nouns, evm, …) store casts under a different
+      // parent_url, so feed/channels returns an empty page for them — the "some channels are
+      // just empty" report. A per-page empty→fallback heuristic would mix hypersnap and Neynar
+      // cursors and break infinite-scroll pagination, so route every channel feed to Neynar for
+      // one consistent pagination source. Revert when haatz indexes channel feeds by id.
+      return unsupported('getChannelFeed');
     },
 
     async getProfileCasts({ fid, limit = 25, cursor, signal }) {
@@ -208,8 +203,15 @@ export function createHypersnapProvider(): FarcasterProvider {
     },
 
     async searchCasts({ q, limit, filters, signal }) {
-      if (filters && Object.keys(filters).length > 0) {
-        // Hypersnap /cast/search is keyword-only; route filtered queries to Neynar via fallback.
+      // haatz /cast/search is keyword-only. `interval` and `viewerFid` are ALWAYS present
+      // (searchService injects a default recency window plus the viewer FID), yet neither
+      // changes which casts match — interval is a best-effort recency window and viewerFid only
+      // adds reaction context. Treating them as "filters" would force every plain keyword search
+      // to the quota-limited Neynar /api/search, which comes back empty. So only fall back for
+      // filters that actually narrow the match set (author / channel / parent_url / mode / sort).
+      const matchNarrowingFilterKeys = ['authorFid', 'channelId', 'parentUrl', 'mode', 'sortType'];
+      if (filters && matchNarrowingFilterKeys.some((key) => filters[key])) {
+        // Hypersnap /cast/search is keyword-only; route narrowed queries to Neynar via fallback.
         unsupported('searchCasts(filters)');
       }
       const data = await fetchJson<{ result: { casts: FarcasterCast[] } }>(

--- a/src/lib/farcaster/providers/index.ts
+++ b/src/lib/farcaster/providers/index.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useCallback, useContext, useMemo } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { getQueryClient } from '@/lib/queryClient';
 import { useUserSettingsStore } from '@/stores/useUserSettingsStore';
 import { createFallbackProvider } from './fallback';
@@ -26,12 +26,19 @@ function createProvider(type: ProviderType): FarcasterProvider {
   return createNeynarProvider();
 }
 
-// Singleton for use outside React (store hydration, etc.)
+// Singleton for use outside React (store hydration, feed hooks, searchService, etc.). Rebuilt
+// whenever the resolved provider type changes: the settings store seeds synchronously from
+// localStorage, but the authoritative value arrives later from Supabase during hydrate(). A
+// singleton pinned at first call would otherwise stay on the wrong provider for the whole
+// session — on a device whose localStorage wasn't seeded yet, that means every feed query runs
+// against the quota-limited Neynar default and silently comes back empty (the onboarding
+// empty-feeds bug).
 let _provider: FarcasterProvider | null = null;
 
 export function getProvider(): FarcasterProvider {
-  if (!_provider) {
-    _provider = createProvider(getProviderType());
+  const type = getProviderType();
+  if (!_provider || _provider.type !== type) {
+    _provider = createProvider(type);
   }
   return _provider;
 }
@@ -85,6 +92,20 @@ export function useFarcasterProviderValue() {
     // cache is discarded on the next cold start.
     getQueryClient().invalidateQueries();
   }, []);
+
+  // hydrate() resolves the authoritative provider from Supabase after the synchronous
+  // localStorage seed, so providerType can flip (e.g. neynar → hypersnap) once the remote
+  // preference loads on a device whose localStorage wasn't seeded yet. When it does, drop the
+  // stale singleton and refetch — the data hooks read getProvider() (not this context), so
+  // without a refetch they keep serving the old provider's empty/quota-limited results. The
+  // ref skips the initial render so a correctly-seeded load doesn't double-fetch.
+  const seededProviderTypeRef = useRef(providerType);
+  useEffect(() => {
+    if (seededProviderTypeRef.current === providerType) return;
+    seededProviderTypeRef.current = providerType;
+    _provider = null;
+    getQueryClient().invalidateQueries();
+  }, [providerType]);
 
   const provider = useMemo(() => createProvider(providerType), [providerType]);
 


### PR DESCRIPTION
## Summary

Onboarding sessions on the Hypersnap provider showed empty feeds because `getProvider()` pinned a singleton at first read (the Neynar default) and never rebuilt it once `hydrate()` resolved the authoritative provider from Supabase, so every feed query ran against quota-limited Neynar — the fix makes the singleton self-healing on type change and refetches when the provider flips during hydration. Channel feeds now fall back to Neynar because haatz `feed/channels` returns empty for most channels (token-gated/chain/legacy parent_urls aren't indexed by id), and plain keyword searches route to haatz `cast/search` instead of the quota-dead Neynar `/api/search` (with a pagination guard since `cast/search` has no offset/cursor). The empty-state discovery cards ("Follow more profiles…", trending channels) now render only on the following-feed empty state, not on channels/lists/searches.

## Testing

`pnpm test` — 133/133 pass (adds `getProvider` singleton self-heal coverage plus Hypersnap channel-feed and search tests); `tsc --noEmit` and `biome check` clean.