### PR TITLE
fix(spaces): detect 'space ended' robustly — toast + teardown instead of dead UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ scripts/benchmark-results/
 
 # Claude Code local state (per-machine permissions, runtime locks)
 .claude/
+.context/

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,5 +24,6 @@ module.exports = {
     '/supabase/functions/', // Deno-based tests, run separately
     '/__tests__/fixtures/', // shared fixture data, not test files
     '/.context/', // gitignored scratch space (research clones, plan docs, etc.)
+    '/.claude/', // agent worktrees/settings — their test copies run in their own checkout
   ],
 };

--- a/src/common/helpers/spaces/livekitRoom.ts
+++ b/src/common/helpers/spaces/livekitRoom.ts
@@ -34,6 +34,9 @@ export class MicPermissionError extends Error {
   }
 }
 
+/** Why a terminal disconnect happened — drives the user-facing message. */
+export type SpaceCloseReason = 'room-ended' | 'removed' | 'other';
+
 export interface LiveKitRoomHandle {
   /** Connect to the SFU and start playing remote audio. Call inside a user
    *  gesture (the Join click) so autoplay is permitted. */
@@ -47,8 +50,9 @@ export interface LiveKitRoomHandle {
   onActiveSpeakers(cb: (fids: number[]) => void): void;
   /** Connected / Reconnecting / Disconnected → SpaceConnState. */
   onConnStateChange(cb: (s: SpaceConnState) => void): void;
-  /** Terminal disconnect (token expiry / kicked) — store rejoins or leaves. */
-  onClosed(cb: () => void): void;
+  /** Terminal disconnect (room ended / kicked / token expiry) — store leaves
+   *  and surfaces `reason` to the user. */
+  onClosed(cb: (reason: SpaceCloseReason) => void): void;
 }
 
 /**
@@ -69,7 +73,7 @@ export function createLiveKitRoom(): LiveKitRoomHandle {
   // Callbacks registered before connect; wired once the Room exists.
   let activeSpeakersCb: ((fids: number[]) => void) | null = null;
   let connStateCb: ((s: SpaceConnState) => void) | null = null;
-  let closedCb: (() => void) | null = null;
+  let closedCb: ((reason: SpaceCloseReason) => void) | null = null;
 
   /** Map a livekit ConnectionState string to our SpaceConnState. */
   function mapConnState(state: string): SpaceConnState {
@@ -150,7 +154,17 @@ export function createLiveKitRoom(): LiveKitRoomHandle {
     async connect(wsUrl: string, token: string): Promise<void> {
       closed = false;
       const livekit = await import('livekit-client');
-      const { Room, RoomEvent, Track } = livekit;
+      const { Room, RoomEvent, Track, DisconnectReason } = livekit;
+
+      /** Map LiveKit's DisconnectReason to our close reason. The host ending
+       *  the Space deletes the LiveKit room → ROOM_DELETED on every client. */
+      const mapCloseReason = (reason: unknown): SpaceCloseReason => {
+        if (reason === DisconnectReason.ROOM_DELETED || reason === DisconnectReason.ROOM_CLOSED) {
+          return 'room-ended';
+        }
+        if (reason === DisconnectReason.PARTICIPANT_REMOVED) return 'removed';
+        return 'other';
+      };
 
       const r = new Room({
         // Audio-only social rooms: always hear everyone, no adaptive logic.
@@ -175,14 +189,14 @@ export function createLiveKitRoom(): LiveKitRoomHandle {
         connStateCb?.(mapConnState(String(state)));
       });
 
-      r.on(RoomEvent.Disconnected, () => {
+      r.on(RoomEvent.Disconnected, (reason?: unknown) => {
         // Terminal: token expired, kicked, or server closed the room. The
         // store decides whether to re-mint a LiveKit token via /join and
         // reconnect (long room) or leave.
         if (closed) return;
         closed = true;
         connStateCb?.('ended');
-        closedCb?.();
+        closedCb?.(mapCloseReason(reason));
       });
 
       await r.connect(wsUrl, token);
@@ -245,7 +259,7 @@ export function createLiveKitRoom(): LiveKitRoomHandle {
       connStateCb = cb;
     },
 
-    onClosed(cb: () => void): void {
+    onClosed(cb: (reason: SpaceCloseReason) => void): void {
       closedCb = cb;
     },
   };

--- a/src/stores/__tests__/useSpacesStore.test.ts
+++ b/src/stores/__tests__/useSpacesStore.test.ts
@@ -40,7 +40,12 @@ const mockLk = {
   isMicEnabled: jest.fn<() => boolean>(() => false),
   onActiveSpeakers: jest.fn<(cb: (fids: number[]) => void) => void>(),
   onConnStateChange: jest.fn<(cb: (s: string) => void) => void>(),
-  onClosed: jest.fn<(cb: () => void) => void>(),
+  onClosed: jest.fn<(cb: (reason: string) => void) => void>(),
+};
+
+const mockToast = {
+  info: jest.fn(),
+  warning: jest.fn(),
 };
 
 class MockMicPermissionError extends Error {
@@ -50,6 +55,7 @@ class MockMicPermissionError extends Error {
   }
 }
 
+jest.mock('sonner', () => ({ toast: mockToast }));
 jest.mock('@/common/helpers/spaces/spacesApi', () => mockApi);
 jest.mock('@/common/helpers/spaces/livekitRoom', () => ({
   createLiveKitRoom: () => mockLk,
@@ -95,8 +101,13 @@ beforeEach(() => {
   accountState.selectedAccountIdx = 0;
   mockLk.isMicEnabled.mockReturnValue(false);
   mockApi.fetchParticipants.mockResolvedValue([]);
+  mockApi.fetchRoom.mockResolvedValue(null);
   resetStore();
 });
+
+/** Flush the microtask queue + one macrotask so void-fired poll/heartbeat
+ *  ticks (and their teardown) settle. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
 // Tear down any timers/handles the store armed during a join so intervals
 // don't leak across tests (the node env runs real setInterval).
@@ -229,6 +240,90 @@ describe('endSpace', () => {
     expect(mockApi.endRoom).toHaveBeenCalledWith('acct-1', 'room-1');
     expect(mockApi.leaveRoom).not.toHaveBeenCalled(); // /end already closes the room
     expect(useSpacesStore.getState().session).toBeNull();
+  });
+});
+
+describe('space-ended detection', () => {
+  it('poll sees room.state=ended → toasts once and tears down without a server leave', async () => {
+    mockApi.joinRoom.mockResolvedValue(joinPayload('listener'));
+    // The immediate post-join poll returns an authoritatively-ended room.
+    mockApi.fetchRoom.mockResolvedValue(room('room-1', 'ended'));
+
+    await useSpacesStore.getState().join('room-1');
+    await flush();
+
+    expect(useSpacesStore.getState().session).toBeNull();
+    expect(mockToast.info).toHaveBeenCalledTimes(1);
+    expect(mockToast.info).toHaveBeenCalledWith(expect.stringContaining('has ended'));
+    // The room is gone — no point firing /leave at it.
+    expect(mockApi.leaveRoom).not.toHaveBeenCalled();
+    expect(mockLk.disconnect).toHaveBeenCalled();
+  });
+
+  it('LiveKit terminal disconnect (room-ended) → toasts and tears down', async () => {
+    mockApi.joinRoom.mockResolvedValue(joinPayload('listener'));
+    let closedCb: ((reason: string) => void) | undefined;
+    mockLk.onClosed.mockImplementation((cb: (reason: string) => void) => {
+      closedCb = cb;
+    });
+
+    await useSpacesStore.getState().join('room-1');
+    expect(useSpacesStore.getState().session).not.toBeNull();
+
+    closedCb!('room-ended');
+    await flush();
+
+    expect(useSpacesStore.getState().session).toBeNull();
+    expect(mockToast.info).toHaveBeenCalledTimes(1);
+    expect(mockApi.leaveRoom).not.toHaveBeenCalled();
+  });
+
+  it('LiveKit removed-from-room → warning toast and server leave', async () => {
+    mockApi.joinRoom.mockResolvedValue(joinPayload('listener'));
+    let closedCb: ((reason: string) => void) | undefined;
+    mockLk.onClosed.mockImplementation((cb: (reason: string) => void) => {
+      closedCb = cb;
+    });
+
+    await useSpacesStore.getState().join('room-1');
+    closedCb!('removed');
+    await flush();
+
+    expect(useSpacesStore.getState().session).toBeNull();
+    expect(mockToast.warning).toHaveBeenCalledWith(expect.stringContaining('removed'));
+    expect(mockApi.leaveRoom).toHaveBeenCalledWith('acct-1', 'room-1');
+  });
+
+  it('does NOT treat a degraded (null) room read as ended', async () => {
+    mockApi.joinRoom.mockResolvedValue(joinPayload('listener'));
+    mockApi.fetchRoom.mockResolvedValue(null); // transient read failure
+
+    await useSpacesStore.getState().join('room-1');
+    await flush();
+
+    expect(useSpacesStore.getState().session).not.toBeNull();
+    expect(mockToast.info).not.toHaveBeenCalled();
+  });
+
+  it('refreshes session.room from the poll snapshot while live', async () => {
+    mockApi.joinRoom.mockResolvedValue(joinPayload('listener'));
+    mockApi.fetchRoom.mockResolvedValue({ ...room('room-1', 'live'), title: 'Renamed by host' });
+
+    await useSpacesStore.getState().join('room-1');
+    await flush();
+
+    expect(useSpacesStore.getState().session?.room.title).toBe('Renamed by host');
+  });
+
+  it('user-initiated leave does not toast', async () => {
+    mockApi.joinRoom.mockResolvedValue(joinPayload('listener'));
+    await useSpacesStore.getState().join('room-1');
+
+    await useSpacesStore.getState().leave();
+    await flush();
+
+    expect(mockToast.info).not.toHaveBeenCalled();
+    expect(mockToast.warning).not.toHaveBeenCalled();
   });
 });
 

--- a/src/stores/useSpacesStore.ts
+++ b/src/stores/useSpacesStore.ts
@@ -24,6 +24,7 @@
 'use client';
 
 import { type Draft, create as mutativeCreate } from 'mutative';
+import { toast } from 'sonner';
 import { create } from 'zustand';
 import {
   SPACE_DISCOVERY_LIMIT,
@@ -33,7 +34,12 @@ import {
   SPACE_POLL_INTERVAL_MS,
   SPACE_SEAT_TTL_MS,
 } from '@/common/constants/spaces';
-import { createLiveKitRoom, type LiveKitRoomHandle, MicPermissionError } from '@/common/helpers/spaces/livekitRoom';
+import {
+  createLiveKitRoom,
+  type LiveKitRoomHandle,
+  MicPermissionError,
+  type SpaceCloseReason,
+} from '@/common/helpers/spaces/livekitRoom';
 import * as spacesApi from '@/common/helpers/spaces/spacesApi';
 import {
   type AudioRoom,
@@ -87,6 +93,9 @@ interface SpacesRuntime {
   accountUnsub: (() => void) | null;
   /** Guards against overlapping join() calls and identifies the live attempt. */
   joinToken: number;
+  /** Room we already showed an "ended" toast for — the LiveKit Disconnected
+   *  event and the room-state poll can both detect the end; toast only once. */
+  endNotifiedRoomId: string | null;
 }
 
 const runtime: SpacesRuntime = {
@@ -99,6 +108,7 @@ const runtime: SpacesRuntime = {
   visibilityListener: null,
   accountUnsub: null,
   joinToken: 0,
+  endNotifiedRoomId: null,
 };
 
 // ---- Account identity helpers --------------------------------------
@@ -164,6 +174,27 @@ function filterStaleSeats(participants: AudioRoomParticipant[]): AudioRoomPartic
   });
 }
 
+// ---- Session-ended notification -------------------------------------
+
+/**
+ * Toast that the session ended for an external reason (host ended the Space,
+ * we were removed, connection lost). NOT called for a user-initiated leave or
+ * a host's own end — those are deliberate. Deduped per room because both the
+ * LiveKit Disconnected event and the room-state poll can detect the same end.
+ */
+function notifySessionEnded(roomId: string, reason: SpaceCloseReason, roomTitle?: string): void {
+  if (runtime.endNotifiedRoomId === roomId) return;
+  runtime.endNotifiedRoomId = roomId;
+  const title = roomTitle ? `“${roomTitle}”` : 'The space';
+  if (reason === 'room-ended') {
+    toast.info(`${title} has ended`);
+  } else if (reason === 'removed') {
+    toast.warning('You were removed from this space');
+  } else {
+    toast.warning('Disconnected from the space');
+  }
+}
+
 // ---- Timer / lifecycle helpers (operate via get/set) ---------------
 
 function clearTimers(): void {
@@ -177,16 +208,38 @@ function clearTimers(): void {
   }
 }
 
-/** One participant-poll tick. Drops the result if the session changed. */
+/**
+ * One poll tick: participants + the authoritative room snapshot. The snapshot
+ * is the robust "this space ended" signal — when the host ends the Space the
+ * control plane flips `room.state` to `'ended'`, even if our LiveKit socket
+ * never gets a clean ROOM_DELETED. On an ended room: toast + full teardown.
+ * Drops results if the session changed.
+ */
 async function pollOnce(get: () => SpacesStore, set: StoreSet, accountId: string, roomId: string): Promise<void> {
   if (!liveSessionFor(get, accountId)) return;
-  const participants = await spacesApi.fetchParticipants(accountId, roomId);
+  const [participants, room] = await Promise.all([
+    spacesApi.fetchParticipants(accountId, roomId),
+    spacesApi.fetchRoom(accountId, roomId),
+  ]);
   // Re-check after the await: switched/left mid-request → drop the stale result.
-  if (!liveSessionFor(get, accountId)) return;
+  const session = liveSessionFor(get, accountId);
+  if (!session) return;
+
+  // `room === null` is a degraded read (transient error) — NOT proof the room
+  // ended; only an explicit ended state tears the session down.
+  if (room && (room.state === 'ended' || room.endedAt)) {
+    notifySessionEnded(roomId, 'room-ended', room.title ?? session.room.title);
+    // No server /leave: the room is gone; the seat dies with it.
+    void teardown(get, set, { serverLeave: false });
+    return;
+  }
+
   const filtered = filterStaleSeats(participants);
   set((state) => {
     if (!state.session || state.session.accountId !== accountId) return;
     state.session.participants = filtered;
+    // Keep the room snapshot fresh (title/listenerCount edits by the host).
+    if (room) state.session.room = room;
   });
 }
 
@@ -371,6 +424,8 @@ const store = (set: StoreSet, get: () => SpacesStore): SpacesStore => ({
 
     const myToken = ++runtime.joinToken;
     const { accountId, accountFid } = identity;
+    // Fresh join → this room may end (again) later and deserves a fresh toast.
+    runtime.endNotifiedRoomId = null;
 
     // 1) Mint via the proxy /join (throws on failure → user stays out).
     let joinResult;
@@ -418,12 +473,15 @@ const store = (set: StoreSet, get: () => SpacesStore): SpacesStore => ({
         }
       });
     });
-    lk.onClosed(() => {
-      // Terminal disconnect (e.g. LiveKit token expiry). v1: tear down + leave.
+    lk.onClosed((reason: SpaceCloseReason) => {
+      // Terminal disconnect: host ended the Space (ROOM_DELETED), we were
+      // removed, or the LiveKit token expired. v1: toast + tear down + leave.
       // A future optimization can re-mint via /join and reconnect here; for v1
       // we leave cleanly so the user is never stuck on dead audio.
       if (runtime.livekit !== lk) return; // superseded
-      void teardown(get, set, { serverLeave: true });
+      notifySessionEnded(roomId, reason, get().session?.room.title);
+      // Skip the server /leave when the room itself ended (it's gone).
+      void teardown(get, set, { serverLeave: reason !== 'room-ended' });
     });
 
     try {


### PR DESCRIPTION
## Problem

When a host ended a Space, listeners were left staring at a dead session with zero feedback — the only way to understand what happened was a page refresh (reported live on prod after re-enabling the flag).

Two gaps:
1. The LiveKit `Disconnected` handler discarded the `DisconnectReason` and tore down silently (when it fired at all).
2. Nothing ever checked the authoritative room state: the participant poll degrades to `[]` on error by design, and heartbeat failures only ever mark the session `degraded` — so a control-plane end without a clean LiveKit disconnect left the session alive forever.

## Fix — two independent end signals

- **LiveKit push**: `livekitRoom` maps the disconnect reason (`ROOM_DELETED`/`ROOM_CLOSED` → `room-ended`, `PARTICIPANT_REMOVED` → `removed`, else `other`) and passes it through `onClosed(reason)`.
- **Control-plane poll**: the existing 5s poll now fetches the room snapshot in parallel with participants; `state === 'ended'` (or `endedAt`) → teardown, even if the socket never says a word. A `null` snapshot (transient read failure) is deliberately **not** treated as ended.

On an external end: small bottom-right sonner toast (`“<title>” has ended` / `You were removed from this space` / `Disconnected from the space`), deduped per room since both signals can fire for the same end. Deliberate exits (own leave, host end, account switch) never toast. When the room itself ended we skip the pointless server `/leave`.

Bonus: the poll snapshot keeps `session.room` (title/listenerCount) fresh while live.

Also: `jest.config.js` now ignores `.claude/` so stale agent worktrees can't fail `pnpm check` on unrelated suite copies.

## Tests

6 new store tests: poll-detects-ended (toast once, no server leave), LiveKit room-ended, removed (warning + server leave), null-snapshot-is-not-ended, snapshot-refreshes-session.room, leave-does-not-toast. 17/17 pass; tsc + biome clean.

## Context

Follow-up to #748 / #761 — Spaces was re-enabled in prod today after confirming Farcaster now accepts the app-key (signer) JWT on `/v1/audio-room*` (per their API docs). This fixes the first UX gap found while dogfooding.