### PR TITLE
feat(#754 stores-hooks): unit #4 — stores + RQ hooks SSR-safety pass

### DIFF
--- a/docs/migration/conventions.md
+++ b/docs/migration/conventions.md
@@ -17,6 +17,8 @@
 | `next/dynamic` (`ssr:false`) | TanStack lazy + `import.meta.env.DEV` guards | Editor/wallet are the main consumers. |
 | `@faker-js/faker` | the Vite `resolve.alias` → `src/lib/faker-stub.ts` (in `vite.config.mts`) | Already wired; prevents a +7.9 MB regression when `@farcaster/core` lands. |
 | Pick a host (CF vs Vercel) | the **`TARGET` flag** in `vite.config.mts` | `cloudflare` (default) vs `vercel` (unblocked on vite 7 by unit #1 — `web:build:vercel`; see `phase-1.md §0.1`). |
+| Browser Supabase client from shared code (stores etc.) | `getSupabaseClient()` — `src/common/helpers/supabase/component.ts` *(unit #4)* | Lazy + singleton. **Never call `createClient()`/`getSupabaseClient()` at module scope** — it throws without env and breaks SSR import. |
+| Read public `NEXT_PUBLIC_*` config in shared code | the **`define` allowlist** in `vite.config.mts` *(unit #4)* | Vite does NOT inline `NEXT_PUBLIC_*`. Each public key shared code reads must be added to the allowlist (sourced from `.env.local`, `VITE_X` preferred) or it is silently `undefined` in the TanStack build. **Secrets are pinned to `undefined` there — never add a secret.** |
 
 ## The `.server.ts` boundary convention (load-bearing — R13)
 

--- a/docs/migration/phase-2-stores-hooks.md
+++ b/docs/migration/phase-2-stores-hooks.md
@@ -1,0 +1,73 @@
+# Unit #4 — stores + RQ hooks SSR-safety pass
+
+> Track B / epic #754. Foundation chain `#3 ✅ → #4 → #5`. Makes the **shared** state layer — the 14 Zustand stores (`src/stores/`) and the React Query hooks (`src/hooks/queries/`) — importable and render-safe under workerd SSR + the Vite client build, so unit #5 (app shell + sidebar) can consume them as-is. Blocked-by: **#3 ✅**. Template: `phase-1.md`. Reuse contract: `conventions.md`.
+
+## Objective
+
+Every store/hook module the app shell needs must (a) **import** without throwing on workerd (module scope runs during SSR) and in the Vite client bundle (where `NEXT_PUBLIC_*` is not inlined and `window` rules differ), and (b) **render** via `useStore(selector)` / `useQuery` during SSR without touching browser globals. Proven by a new SSR probe route that imports the entire store + query-hook surface.
+
+## Non-goals
+
+- **No data fetching on the server** — RQ hooks fetch client-side only (no suspense/prefetch here; loaders come with the page ports, units #5–#7).
+- **No store hydration on the server** — `initializeStores*` stays a client-mount concern (unit #5 wires it).
+- **No porting of `/api/*` endpoints** the hooks call (units #10/#11). On the worker the hooks' client-side fetches 404 until then — the probe only proves render-safety, not data.
+- **No behavior change for the live Next app** — shared-file edits must be timing-only (lazy init), never semantic.
+
+## Audit findings (what actually breaks, verified on `main`)
+
+| # | Hazard | Where | Class |
+|---|--------|-------|-------|
+| H1 | **Module-scope `createClient()`** — throws when `NEXT_PUBLIC_SUPABASE_*` is absent (always, in the Vite client bundle; and on workerd unless inlined). Breaks *import*, not just use. | `useDraftStore.ts:273`, `useListStore.ts:81`, `useNotificationStore.ts:21`, `useUserStore.ts:27` | fix (lazy) |
+| H2 | **`process.env.NEXT_PUBLIC_*` reads are not inlined by Vite** — resolve `undefined` (Supabase URL/key, APP_FID, HYPERSNAP_URL, ENABLE_SPACES, URL). | `supabase/component.ts`, `useAccountStore.ts:25`, `hypersnap.ts:34`, `constants/spaces.ts:11`, `useSocialGraphSync.ts:7` | fix (vite `define`) |
+| H3 | Module-scope `window`/`document` listeners | `useNotificationStore`, `useWorkspaceStore`, `usePerformanceStore` | already `typeof window` guarded ✅ |
+| H4 | `persist` storage: IndexedDB wrapper + `sessionStorage` getter | `StoreStorage.ts`, `useDraftStore.ts:821` | already safe (ctor guard; zustand v4 `createJSONStorage` try/catches) ✅ |
+| H5 | zustand render path during SSR | all stores | safe — v4 `useSyncExternalStore` with `getState` server snapshot ✅ |
+| H6 | **`@farcaster/core` runs `Factory.build()` → `randomBytes` at module scope** inside its bundled test factories (`MessageDataFactory.params({ verificationRemoveBody: VerificationRemoveBodyFactory.build(…) })`) — workerd forbids random generation in global scope; killed SSR of any route whose graph touches the package. *(Found empirically on workerd — invisible to `vite build`.)* | `@farcaster/core/dist/index.mjs` (via `useDraftStore` → `helpers/farcaster`) | fix (rollup `treeshake.moduleSideEffects` declares the module side-effect-free; nothing imports `Factories`, so the whole chain tree-shakes out — server route chunk also shrank 1108→792 kB) |
+| H7 | **`useWorkspaceStore` seeded `initialState.layout` with `crypto.randomUUID()` at module scope** — same workerd global-scope restriction, plus a latent SSR/client hydration mismatch (server and client generated different default panel ids). *(Found empirically after H6 was fixed.)* | `useWorkspaceStore.ts:30` | fix (fixed `DEFAULT_PANEL_ID` sentinel for the default panel; runtime `addPanel` still uses random UUIDs; persisted layouts replace the default wholesale) |
+
+**Fix strategy (seam-conformant):**
+
+1. **Lazy Supabase client (shared-file edit, timing-only):** a new shared `getSupabaseClient()` in `src/common/helpers/supabase/component.ts` (lazy + singleton — `createClient()` already caches internally); the four stores import it instead of creating clients at module scope. *(Tier-1 review outcome: extracted to ONE helper rather than copying the per-store getter pattern a 4th–7th time; `useWorkspaceStore`/`useAccountStore`/`userPreferencesSync` keep their pre-existing local getters — converging them is cheap follow-up churn, not unit scope.)* Next app behavior is identical (singleton, created on first use instead of at import). Required regardless of env inlining: the **forkability bar** says the probe must render with **no secrets present**.
+2. **Vite `define` for public `NEXT_PUBLIC_*` config (`vite.config.mts` only):** inline the *public* keys at build time from `.env.local` (`VITE_X` preferred, `NEXT_PUBLIC_X` accepted so the Next app's existing `.env.local` works unchanged). **Explicitly pinned to `undefined`: `NEXT_PUBLIC_NEYNAR_API_KEY` and `NEXT_PUBLIC_APP_MNENOMIC`** — never inline secrets into the client bundle (#751; the TanStack path keeps Neynar server-side).
+   *Why `define` and not editing `component.ts` to read `import.meta.env`:* Jest is ts-jest/CJS — `import.meta` in a shared file is a syntax error in the test graph; `define` needs zero shared-file edits.
+
+## Files
+
+- **New:** `docs/migration/phase-2-stores-hooks.md` (this file), `src/web/routes/stores-probe.tsx`.
+- **Edit (migration-owned):** `vite.config.mts` (define block + `@farcaster/core` treeshake rule), `docs/migration/strategy.md` (status), `docs/migration/conventions.md` (two new seam rows: `getSupabaseClient`, the `NEXT_PUBLIC_*` define allowlist).
+- **Edit (shared, timing-only):** `src/common/helpers/supabase/component.ts` (adds `getSupabaseClient()`), `src/stores/useDraftStore.ts`, `useListStore.ts`, `useNotificationStore.ts`, `useUserStore.ts` (module-scope client → shared lazy getter), `src/stores/useWorkspaceStore.ts` (H7 fixed default-panel id).
+- **Untouched:** `app/`, `pages/`, `next.config.mjs`, `vercel.json`, `src/globals.css`, all other shared files.
+
+## The probe — `/stores-probe` (SSR route)
+
+Imports **all 14 store modules** (incl. `initializeStores`) + **all 14 query-hook modules**, then:
+- SSR-renders a selector read from every store (`useXxxStore(s => …)`) — proves the `useSyncExternalStore` server path end-to-end.
+- Mounts one real RQ hook (`useTrendingFeed`, small limit) — SSR renders its pending state; on the client it fetches `/api/feeds/trending` (404 on the worker until unit #10 — the probe renders the error state gracefully and says so).
+- Client-mount effect flips a "client stores OK" flag after exercising a `getState()` read+write round-trip — distinguishes SSR output from hydrated output.
+- Renders an evidence panel: store selector snapshot, RQ status, hydration flag.
+
+Like `migration-probe`, it is **throwaway** — deleted at cutover (#13).
+
+## Definition of Done / cf-canary (status as implemented)
+
+- [x] `pnpm web:typecheck`, `pnpm web:build`, live `pnpm typecheck` all 0; jest 150/150 green.
+- [x] `/stores-probe` SSR-renders **200 on workerd with no secrets** (`pnpm web:serve`, no `.dev.vars`/`.env.local`) — forkability bar. All 12 store selectors render real values in the SSR HTML; no React error boundary; `useTrendingFeed` renders `pending`.
+- [x] All store/hook modules in the route graph — no `Rollup failed to resolve`, no import-time throw on workerd (H6/H7 were exactly this class, found and fixed).
+- [x] Client bundle contains **no** `NEYNAR_API_KEY` / `APP_MNENOMIC` name or value (grepped dist assets).
+- [x] Worker bundle **2433 KiB gzip < 3 MB** (`web:deploy:dry-run`) — ⚠️ **watch item**: up from 578 KiB; the probe drags the full store/hook surface (rainbowkit, livekit, farcaster chains) into the worker. Expected to be the high-water mark until real routes replace the probe; revisit at unit #5.
+- [ ] Hydration: evidence panel flips to "client stores OK" in a real browser. *(Not verifiable in this sandbox — no browser. Check on the cf canary after deploy; SSR output is proven, and the round-trip is a `getState()` toggle that jest-covered stores exercise.)*
+
+## Gotchas (this unit)
+
+- `define` values must be emitted as the literal `undefined` (not the string `"undefined"`) when unset, so existing `!url` guards behave.
+- `define` applies to **both** the client and workerd bundles — fine for public config, which is why secrets are pinned out explicitly.
+- The probe must NOT call `initializeStores()` during SSR (hydration is client-only by design); importing it is the test.
+- `useDraftStore`'s draft chain pulls `@farcaster/core` → the faker alias (`vite.config.mts`) is what keeps the bundle sane; do not remove.
+- Stores write to the **shared** `@/lib/queryClient` singleton — same instance the #3 provider tree serves; no second client.
+
+## Follow-ups surfaced (not fixed here)
+
+- `useWorkspaceStore` / `useAccountStore` / `userPreferencesSync` still carry their pre-existing local lazy-getter copies — converge them onto the shared `getSupabaseClient()` in a later cleanup pass (pure churn, zero behavior change).
+
+- The worker has no `/api/*` data endpoints yet, so client-side hook fetches 404 on the canary until units #10/#11 — expected, visible in the probe.
+- `useSocialGraphSync.ts` (non-query hook) and other `src/hooks/*` outside `queries/` get the same `define` coverage but are exercised by unit #5's shell, not this probe.

--- a/docs/migration/strategy.md
+++ b/docs/migration/strategy.md
@@ -30,7 +30,7 @@ Sizes leveled (S/M/L, none >~2× another). Status: ☐ todo · ◐ in-progress �
 | 1 | chore: bump vite 6→7 (unblocks Vercel target) | S | ✅ | — | `phase-2-vite7.md` |
 | 2 | port: `next/navigation` → TanStack adapter (54 sites) | L | ✅ | — *(gate)* | `phase-2-navigation-seam.md` |
 | 3 | port: provider tree (wallet/posthog/persist/auth ctx) | L | ✅ | 2 | `phase-2-providers.md` |
-| 4 | port: stores + RQ hooks SSR-safety pass | S–M | ☐ | 3 | `phase-2-stores-hooks.md` |
+| 4 | port: stores + RQ hooks SSR-safety pass | S–M | 🔍 | 3 | `phase-2-stores-hooks.md` |
 | 5 | port: app shell + sidebar + command palette | L | ☐ | 2,3,4 | `phase-2-shell.md` |
 | 6 | port: feeds + profile (CastRow + react-virtual) | L | ☐ | 5 | `phase-2-feeds-profile.md` |
 | 7 | port: inbox + search + conversation | M–L | ☐ | 6 | `phase-2-inbox-search.md` |

--- a/src/common/helpers/supabase/component.ts
+++ b/src/common/helpers/supabase/component.ts
@@ -34,3 +34,14 @@ export function createClient(): SupabaseClient<Database> {
   supabaseInstance = createBrowserClient<Database>(url, anonKey);
   return supabaseInstance;
 }
+
+/**
+ * Lazy accessor for the singleton browser client. Identical to calling createClient()
+ * (which caches internally) — the separate name exists so modules that must be importable
+ * without env vars present (the zustand stores, anything reachable from SSR) have one
+ * canonical way to defer client creation (and its missing-env throw) to first use instead
+ * of module scope. Do not call at module scope.
+ */
+export function getSupabaseClient(): SupabaseClient<Database> {
+  return createClient();
+}

--- a/src/stores/useDraftStore.ts
+++ b/src/stores/useDraftStore.ts
@@ -18,7 +18,7 @@ import {
 } from '@/common/constants/farcaster';
 import { NewPostDraft } from '@/common/constants/postDrafts';
 import { formatPlaintextToHubCastMessage, getMentionFidsByUsernames, submitCast } from '@/common/helpers/farcaster';
-import { createClient } from '@/common/helpers/supabase/component';
+import { getSupabaseClient } from '@/common/helpers/supabase/component';
 import {
   toastErrorCastPublish,
   toastInfoReadOnlyMode,
@@ -270,8 +270,6 @@ export const mutative = (config) => (set, get) => config((fn) => set(mutativeCre
 
 type StoreSet = (fn: (draft: Draft<DraftStore>) => void) => void;
 
-const supabaseClient = createClient();
-
 const store = (set: StoreSet) => ({
   drafts: [],
   isHydrated: false,
@@ -447,7 +445,7 @@ const store = (set: StoreSet) => ({
       }
 
       // Insert into DB (async OUTSIDE set)
-      const { data, error } = await supabaseClient
+      const { data, error } = await getSupabaseClient()
         .from('draft')
         .insert({
           account_id: account.id,
@@ -531,7 +529,7 @@ const store = (set: StoreSet) => ({
     });
   },
   removeScheduledDraftFromDB: async (draftId: string): Promise<boolean> => {
-    const { data, error } = await supabaseClient
+    const { data, error } = await getSupabaseClient()
       .from('draft')
       .update({ status: DraftStatus.removed })
       .eq('id', draftId)
@@ -549,7 +547,7 @@ const store = (set: StoreSet) => ({
     return true;
   },
   hydrate: async () => {
-    supabaseClient
+    getSupabaseClient()
       .from('draft')
       .select('*')
       .neq('status', DraftStatus.removed)

--- a/src/stores/useListStore.ts
+++ b/src/stores/useListStore.ts
@@ -2,7 +2,7 @@ import { type Draft, create as mutativeCreate } from 'mutative';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { MAX_FID_LIST_SIZE, MAX_FID_LIST_SIZE_MESSAGE, MAX_USERS_PER_LIST } from '@/common/constants/listLimits';
-import { createClient } from '@/common/helpers/supabase/component';
+import { getSupabaseClient } from '@/common/helpers/supabase/component';
 import type { Tables, TablesInsert, TablesUpdate } from '@/common/types/database.types';
 import { type AutoInteractionListContent, type FidListContent, isFidListContent } from '@/common/types/list.types';
 
@@ -78,8 +78,6 @@ export const mutative =
 
 type StoreSet = (fn: (draft: Draft<ListStore>) => void) => void;
 
-const supabaseClient = createClient();
-
 const store = (set: StoreSet, get: () => ListStore): ListStore => ({
   lists: [],
   searches: [],
@@ -117,7 +115,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
         updatedDisplayNames[fid] = displayName;
       }
 
-      const { data, error } = await supabaseClient
+      const { data, error } = await getSupabaseClient()
         .from('list')
         .update({
           contents: {
@@ -155,7 +153,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
         delete updatedDisplayNames[fid];
       }
 
-      const { data, error } = await supabaseClient
+      const { data, error } = await getSupabaseClient()
         .from('list')
         .update({
           contents: {
@@ -191,7 +189,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
         [fid]: displayName,
       };
 
-      const { data, error } = await supabaseClient
+      const { data, error } = await getSupabaseClient()
         .from('list')
         .update({
           contents: {
@@ -216,7 +214,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
   addFidList: async (name: string, fids: string[]) => {
     const {
       data: { user },
-    } = await supabaseClient.auth.getUser();
+    } = await getSupabaseClient().auth.getUser();
     if (!user) {
       return { success: false, error: 'User not logged in' };
     }
@@ -235,7 +233,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
       displayNames: {}, // Initialize empty display names mapping
     };
 
-    const { data: list, error } = await supabaseClient
+    const { data: list, error } = await getSupabaseClient()
       .from('list')
       .insert({
         name,
@@ -258,7 +256,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
   addList: async (newList: AddListType) => {
     const {
       data: { user },
-    } = await supabaseClient.auth.getUser();
+    } = await getSupabaseClient().auth.getUser();
     if (!user) {
       return { success: false, error: 'User not logged in' };
     }
@@ -267,7 +265,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
     const lists = useListStore.getState().lists;
     const highestIdx = lists.length > 0 ? Math.max(...lists.map((list) => list.idx)) : 0;
 
-    const { data: list, error } = await supabaseClient
+    const { data: list, error } = await getSupabaseClient()
       .from('list')
       .insert({
         ...newList,
@@ -300,7 +298,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
       return { success: false, error: MAX_FID_LIST_SIZE_MESSAGE };
     }
 
-    const { data, error } = await supabaseClient.from('list').update(updateData).eq('id', id).select();
+    const { data, error } = await getSupabaseClient().from('list').update(updateData).eq('id', id).select();
 
     if (error) {
       return { success: false, error: `Failed to update list: ${error.message}` };
@@ -329,7 +327,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
       displayNames = existingList.contents.displayNames || {};
     }
 
-    const { data, error } = await supabaseClient
+    const { data, error } = await getSupabaseClient()
       .from('list')
       .update({
         name,
@@ -352,7 +350,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
     return { success: true };
   },
   removeList: async (listId: string) => {
-    const { error } = await supabaseClient.from('list').delete().eq('id', listId);
+    const { error } = await getSupabaseClient().from('list').delete().eq('id', listId);
     if (error) {
       return { success: false, error: 'Failed to remove list' };
     }
@@ -394,7 +392,10 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
     if (useListStore.getState().isHydrated) return;
 
     try {
-      const { data: lists, error } = await supabaseClient.from('list').select('*').order('idx', { ascending: true });
+      const { data: lists, error } = await getSupabaseClient()
+        .from('list')
+        .select('*')
+        .order('idx', { ascending: true });
 
       if (error) {
         throw new Error('Failed to fetch lists from server');
@@ -422,7 +423,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
   ) => {
     const {
       data: { user },
-    } = await supabaseClient.auth.getUser();
+    } = await getSupabaseClient().auth.getUser();
     if (!user) {
       return { success: false, error: 'User not logged in' };
     }
@@ -447,7 +448,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
       requiredKeywords,
     };
 
-    const { data: list, error } = await supabaseClient
+    const { data: list, error } = await getSupabaseClient()
       .from('list')
       .insert({
         name,
@@ -477,7 +478,7 @@ const store = (set: StoreSet, get: () => ListStore): ListStore => ({
     const currentContent = list.contents as AutoInteractionListContent;
     const updatedContent = { ...currentContent, ...settings };
 
-    const { data, error } = await supabaseClient
+    const { data, error } = await getSupabaseClient()
       .from('list')
       .update({
         contents: updatedContent,

--- a/src/stores/useNotificationStore.ts
+++ b/src/stores/useNotificationStore.ts
@@ -3,7 +3,7 @@ import debounce from 'lodash.debounce';
 import { type Draft, create as mutativeCreate } from 'mutative';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
-import { createClient } from '@/common/helpers/supabase/component';
+import { getSupabaseClient } from '@/common/helpers/supabase/component';
 
 const IDB_DATABASE_NAME = 'herocast-notifications';
 const IDB_STORE_NAME = 'notification-read-states';
@@ -17,8 +17,6 @@ const READ_STATE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
 
 // Mutative middleware
 const mutative = (config) => (set, get) => config((fn) => set(mutativeCreate(fn)), get);
-
-const supabaseClient = createClient();
 
 interface NotificationReadState {
   notificationId: string;
@@ -209,7 +207,7 @@ const store = (set: StoreSet, get) => ({
   hydrate: async () => {
     try {
       // Fetch read states from Supabase
-      const { data, error } = await supabaseClient
+      const { data, error } = await getSupabaseClient()
         .from('notification_read_states')
         .select('notification_id, notification_type, read_at')
         .order('read_at', { ascending: false });
@@ -289,7 +287,7 @@ const store = (set: StoreSet, get) => ({
       // Get current user
       const {
         data: { user },
-      } = await supabaseClient.auth.getUser();
+      } = await getSupabaseClient().auth.getUser();
       if (!user) {
         console.log('No authenticated user, skipping sync');
         return;
@@ -318,7 +316,7 @@ const store = (set: StoreSet, get) => ({
       if (typeof navigator !== 'undefined' && navigator.sendBeacon && document.visibilityState === 'hidden') {
         const {
           data: { session },
-        } = await supabaseClient.auth.getSession();
+        } = await getSupabaseClient().auth.getSession();
         if (session) {
           const payload = {
             items,
@@ -338,7 +336,7 @@ const store = (set: StoreSet, get) => ({
       }
 
       // Regular sync
-      const { error } = await supabaseClient.from('notification_read_states').upsert(items, {
+      const { error } = await getSupabaseClient().from('notification_read_states').upsert(items, {
         onConflict: 'user_id,notification_id',
         ignoreDuplicates: false,
       });

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -2,7 +2,7 @@ import { type Draft, create as mutativeCreate } from 'mutative';
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { addUnsafeCustomerForUser, getCustomersForUser } from '@/common/helpers/supabase';
-import { createClient } from '@/common/helpers/supabase/component';
+import { getSupabaseClient } from '@/common/helpers/supabase/component';
 import { toastErrorUpgradeAccount } from '@/common/helpers/toast';
 import type { Tables, TablesInsert } from '@/common/types/database.types';
 
@@ -24,8 +24,6 @@ export const mutative = (config) => (set, get) => config((fn) => set(mutativeCre
 
 type StoreSet = (fn: (draft: Draft<UserStore>) => void) => void;
 
-const supabaseClient = createClient();
-
 const store = (set: StoreSet) => ({
   customer: undefined,
   addUnsafeCustomerForUser: async (customer: Omit<InsertCustomer, 'user_id'>) => {
@@ -34,7 +32,7 @@ const store = (set: StoreSet) => ({
       return;
     }
 
-    addUnsafeCustomerForUser(supabaseClient, customer).then((didAddCustomer) => {
+    addUnsafeCustomerForUser(getSupabaseClient(), customer).then((didAddCustomer) => {
       if (!didAddCustomer) {
         toastErrorUpgradeAccount('Failed to store upgrade data');
         return;
@@ -46,7 +44,7 @@ const store = (set: StoreSet) => ({
     });
   },
   hydrate: async () => {
-    getCustomersForUser(supabaseClient).then((customer) => {
+    getCustomersForUser(getSupabaseClient()).then((customer) => {
       set((state) => {
         state.customer = customer;
       });

--- a/src/stores/useWorkspaceStore.ts
+++ b/src/stores/useWorkspaceStore.ts
@@ -26,11 +26,19 @@ const generateUUID = (): string => {
 
 /**
  * Default layout: Single trending feed panel at 100%
+ *
+ * The default panel uses a FIXED id (not generateUUID()): this function runs at module
+ * scope to seed the store's initial state, and generating random values during module
+ * evaluation is disallowed on Cloudflare workerd (SSR) — it also kept server- and
+ * client-rendered initial layouts from matching. Panels added at runtime (addPanel)
+ * still get random UUIDs; a persisted/hydrated layout replaces this default wholesale.
  */
+const DEFAULT_PANEL_ID = 'panel-default';
+
 const createDefaultLayout = (): WorkspaceLayout => ({
   panels: [
     {
-      id: generateUUID(),
+      id: DEFAULT_PANEL_ID,
       type: 'feed',
       config: { feedType: 'trending' },
       collapsed: false,

--- a/src/web/routes/stores-probe.tsx
+++ b/src/web/routes/stores-probe.tsx
@@ -1,0 +1,165 @@
+// THROWAWAY / INTERNAL — unit #4 (stores + RQ hooks SSR-safety) probe. Deleted at/before cutover.
+//
+// Imports the ENTIRE shared state surface — all 12 Zustand store hooks (plus
+// initializeStores / userPreferencesSync / StoreStorage via their import chains) and all
+// 14 React Query hook modules under src/hooks/queries/ — and SSR-renders a selector read
+// from every store. That exercises, on real workerd:
+//   - module evaluation of every store/hook (no import-time window/localStorage/env throw;
+//     Supabase clients are lazy as of this unit; public NEXT_PUBLIC_* config is inlined by
+//     the vite `define` block)
+//   - zustand's useSyncExternalStore server-snapshot path for every store
+//   - one real RQ hook (useTrendingFeed) rendering its pending state during SSR; on the
+//     client it fetches through the FarcasterProvider seam (expected to error on the worker
+//     until the data routes port in unit #10 — the probe renders that state honestly)
+//   - a client-mount store write/read round-trip (toggleCommandPalette), proving the
+//     hydrated client tree shares the same store instances
+//
+// Per the forkability bar, this page must render 200 with NO secrets configured.
+//
+// NOTE: the filename must NOT start with `_` — a leading underscore is TanStack's
+// pathless/layout-route convention and would mount this at `/` instead of /stores-probe.
+// Mirrors nav-probe.tsx / providers-probe.tsx / migration-probe.tsx.
+import { createFileRoute } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+// React Query hooks — import every module so its chain is proven in the route graph.
+// (Only useTrendingFeed is mounted; the rest just need to survive bundling + evaluation.)
+import { getProfileBatcher } from '@/hooks/queries/profileBatcher';
+import { useBestFriends } from '@/hooks/queries/useBestFriends';
+import { useBulkProfiles } from '@/hooks/queries/useBulkProfiles';
+import { useCastReactions } from '@/hooks/queries/useCastReactions';
+import { useCastSearchInfinite } from '@/hooks/queries/useCastSearch';
+import { useChannelFeed } from '@/hooks/queries/useChannelFeed';
+import { useTrendingChannels } from '@/hooks/queries/useChannelQueries';
+import { useFidListFeed } from '@/hooks/queries/useFidListFeed';
+import { useFollowingFeed } from '@/hooks/queries/useFollowingFeed';
+import { useProfile } from '@/hooks/queries/useProfile';
+import { useProfileFeed } from '@/hooks/queries/useProfileFeed';
+import { useSearchListFeedInfinite } from '@/hooks/queries/useSearchListFeed';
+import { useTrendingFeed } from '@/hooks/queries/useTrendingFeed';
+import { useUrlMetadata } from '@/hooks/queries/useUrlMetadata';
+// initializeStores must be IMPORTABLE on the server (calling it stays client-only — unit #5).
+import { initializeStores } from '@/stores/initializeStores';
+// Zustand stores — the full surface (side-effect-free to import; that's the test).
+import { useAccountStore } from '@/stores/useAccountStore';
+import { useDataStore } from '@/stores/useDataStore';
+import { useDraftStore } from '@/stores/useDraftStore';
+import { useListStore } from '@/stores/useListStore';
+import { useNavigationStore } from '@/stores/useNavigationStore';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+import { usePerformanceStore } from '@/stores/usePerformanceStore';
+import { useSocialGraphStore } from '@/stores/useSocialGraphStore';
+import { useSpacesStore } from '@/stores/useSpacesStore';
+import { useUserSettingsStore } from '@/stores/useUserSettingsStore';
+import { useUserStore } from '@/stores/useUserStore';
+import { useWorkspaceStore } from '@/stores/useWorkspaceStore';
+
+export const Route = createFileRoute('/stores-probe')({
+  component: StoresProbe,
+});
+
+// Referenced (not invoked) so bundlers can't tree-shake the imports away — every module
+// above must survive evaluation in BOTH the workerd and client bundles.
+const importedHookModules = [
+  getProfileBatcher,
+  useBestFriends,
+  useBulkProfiles,
+  useCastReactions,
+  useCastSearchInfinite,
+  useChannelFeed,
+  useTrendingChannels,
+  useFidListFeed,
+  useFollowingFeed,
+  useProfile,
+  useProfileFeed,
+  useSearchListFeedInfinite,
+  useUrlMetadata,
+  initializeStores,
+] as const;
+
+function StoresProbe() {
+  // One selector per store: proves zustand's server-snapshot render path end-to-end.
+  const accounts = useAccountStore((s) => s.accounts.length);
+  const dataKeys = useDataStore((s) => Object.keys(s).length);
+  const drafts = useDraftStore((s) => s.drafts.length);
+  const lists = useListStore((s) => s.lists.length);
+  const commandPaletteOpen = useNavigationStore((s) => s.isCommandPaletteOpen);
+  const notificationQueue = useNotificationStore((s) => s.syncQueue.length);
+  const perfMetrics = usePerformanceStore((s) => s.metrics.length);
+  const socialGraphKeys = useSocialGraphStore((s) => Object.keys(s).length);
+  const spacesKeys = useSpacesStore((s) => Object.keys(s).length);
+  const farcasterProvider = useUserSettingsStore((s) => s.farcasterProvider);
+  const userKeys = useUserStore((s) => Object.keys(s).length);
+  const workspaceHydrated = useWorkspaceStore((s) => s.isHydrated);
+
+  // Real RQ hook through the FarcasterProvider seam. SSR renders 'pending'; the client
+  // fetch will error on the worker until unit #10 ports the data routes — expected.
+  const trending = useTrendingFeed({ limit: 2 });
+
+  // Client round-trip: write to a store after mount and read the result back through the
+  // same hook the server rendered with. Distinguishes hydrated output from SSR output.
+  const [clientStoresOk, setClientStoresOk] = useState(false);
+  useEffect(() => {
+    const before = useNavigationStore.getState().isCommandPaletteOpen;
+    useNavigationStore.getState().toggleCommandPalette();
+    const after = useNavigationStore.getState().isCommandPaletteOpen;
+    useNavigationStore.getState().toggleCommandPalette(); // restore
+    setClientStoresOk(before !== after);
+  }, []);
+
+  const storeSnapshot: Record<string, string | number | boolean> = {
+    'accountStore.accounts': accounts,
+    'dataStore (keys)': dataKeys,
+    'draftStore.drafts': drafts,
+    'listStore.lists': lists,
+    'navigationStore.isCommandPaletteOpen': commandPaletteOpen,
+    'notificationStore.syncQueue': notificationQueue,
+    'performanceStore.metrics': perfMetrics,
+    'socialGraphStore (keys)': socialGraphKeys,
+    'spacesStore (keys)': spacesKeys,
+    'userSettingsStore.farcasterProvider': farcasterProvider,
+    'userStore (keys)': userKeys,
+    'workspaceStore.isHydrated': workspaceHydrated,
+  };
+
+  return (
+    <main style={{ maxWidth: 640, margin: '0 auto', padding: 24, lineHeight: 1.5 }}>
+      <h1>stores + hooks probe</h1>
+      <p>
+        <small>
+          Internal / throwaway (unit #4). All {Object.keys(storeSnapshot).length} Zustand stores +{' '}
+          {importedHookModules.length} query-hook modules imported and SSR-rendered.
+        </small>
+      </p>
+
+      <h2>Store selectors (rendered during SSR)</h2>
+      <ul>
+        {Object.entries(storeSnapshot).map(([k, v]) => (
+          <li key={k}>
+            {k}: <code>{String(v)}</code>
+          </li>
+        ))}
+      </ul>
+
+      <h2>React Query hook (useTrendingFeed via FarcasterProvider)</h2>
+      <ul>
+        <li>
+          status: <code>{trending.status}</code>{' '}
+          <small>(client fetch is expected to error until unit #10 ports the data routes)</small>
+        </li>
+        <li>
+          casts: <code>{trending.data?.casts?.length ?? 'n/a'}</code>
+        </li>
+        <li>
+          error: <code>{trending.error ? String(trending.error) : 'none'}</code>
+        </li>
+      </ul>
+
+      <h2>Client hydration</h2>
+      <ul>
+        <li>
+          store write/read round-trip: <code>{clientStoresOk ? 'client stores OK' : '(hydrating…)'}</code>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -3,7 +3,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import viteReact from '@vitejs/plugin-react';
 import { nitro } from 'nitro/vite';
 import { fileURLToPath } from 'node:url';
-import { defineConfig, type PluginOption } from 'vite';
+import { defineConfig, loadEnv, type PluginOption } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 // TanStack Start + Cloudflare Workers wiring (proven by the Phase-0 spike, see
@@ -39,7 +39,54 @@ const hostPlugins: PluginOption[] = isCloudflare
   ? [cloudflare({ viteEnvironment: { name: 'ssr' } })]
   : [nitro({ config: { preset: 'vercel' } })];
 
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  // Unit #4 (#754 stores/hooks SSR-safety): the shared stores + hooks read PUBLIC client
+  // config via `process.env.NEXT_PUBLIC_*`, which the Next build inlines but Vite does not
+  // (the reads resolve to `undefined`, and Supabase client creation then throws). Inline
+  // the public keys here at build time, sourced from the same `.env.local` the Next app
+  // already uses (`VITE_X` preferred, `NEXT_PUBLIC_X` accepted). This is build-time text
+  // replacement across BOTH the client and workerd bundles — public values only.
+  //
+  // SECRETS ARE PINNED OUT: `NEXT_PUBLIC_NEYNAR_API_KEY` and `NEXT_PUBLIC_APP_MNENOMIC`
+  // are deliberately forced to `undefined` so they can never be inlined into the client
+  // bundle (#751 — the TanStack path keeps the Neynar key server-side via serverEnv()).
+  const publicEnv = loadEnv(mode, process.cwd(), ['VITE_', 'NEXT_PUBLIC_']);
+  // `define` values are CODE TEXT injected into the bundle: a set key becomes a quoted
+  // string via JSON.stringify; an unset key becomes the text `undefined` (JSON.stringify
+  // of undefined is undefined, so `?? 'undefined'` kicks in), which evaluates to the
+  // literal undefined at runtime — keeping the existing `!url` guards in shared code
+  // working. Do NOT "simplify" the `?? 'undefined'` away.
+  const inlinePublic = (nextKey: string): string =>
+    JSON.stringify(publicEnv[nextKey.replace(/^NEXT_PUBLIC_/, 'VITE_')] ?? publicEnv[nextKey]) ?? 'undefined';
+  const define = {
+    'process.env.NEXT_PUBLIC_SUPABASE_URL': inlinePublic('NEXT_PUBLIC_SUPABASE_URL'),
+    'process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY': inlinePublic('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
+    'process.env.NEXT_PUBLIC_APP_FID': inlinePublic('NEXT_PUBLIC_APP_FID'),
+    'process.env.NEXT_PUBLIC_HYPERSNAP_URL': inlinePublic('NEXT_PUBLIC_HYPERSNAP_URL'),
+    'process.env.NEXT_PUBLIC_ENABLE_SPACES': inlinePublic('NEXT_PUBLIC_ENABLE_SPACES'),
+    'process.env.NEXT_PUBLIC_URL': inlinePublic('NEXT_PUBLIC_URL'),
+    'process.env.NEXT_PUBLIC_NEYNAR_API_KEY': 'undefined', // secret — never inline (#751)
+    'process.env.NEXT_PUBLIC_APP_MNENOMIC': 'undefined', // secret — never inline
+  };
+
+  return {
+  define,
+  build: {
+    rollupOptions: {
+      treeshake: {
+        // Unit #4 (#754): @farcaster/core's single-file bundle runs `Factory.build()` AT
+        // MODULE SCOPE inside its test-factory definitions (`MessageDataFactory.params({
+        // verificationRemoveBody: VerificationRemoveBodyFactory.build(...) })`), which
+        // calls `randomBytes` during module evaluation — workerd forbids that in global
+        // scope ("Disallowed operation called within global scope") and the SSR render
+        // dies. Nothing in the app imports `Factories`, so declaring the module
+        // side-effect-free lets Rollup tree-shake the whole factory chain (incl. the
+        // offending module-scope calls) out of both bundles. Everything else keeps
+        // default side-effect handling.
+        moduleSideEffects: (id) => !id.includes('/@farcaster/core/'),
+      },
+    },
+  },
   // Plugin ORDER IS LOAD-BEARING — do NOT reorder (any change here is a bug, R1 in the plan):
   //   1. host plugin (cloudflare) pins the SSR environment to workerd
   //   2. tanstackStart() MUST come before viteReact()
@@ -125,4 +172,5 @@ export default defineConfig({
         },
       }
     : {}),
+  };
 });


### PR DESCRIPTION
Make the shared state layer (12 Zustand stores + the src/hooks/queries surface)
importable and render-safe under workerd SSR and the Vite client build, proven
by a new /stores-probe SSR route that imports the entire surface and renders a
selector from every store.

- vite.config.mts: define-inline the public NEXT_PUBLIC_* config from .env.local
  (VITE_* preferred); NEYNAR_API_KEY / APP_MNENOMIC pinned to undefined so
  secrets can never reach the client bundle (#751).
- vite.config.mts: declare @farcaster/core side-effect-free for rollup — its
  bundled test factories run Factory.build() -> randomBytes at module scope,
  which workerd forbids in global scope and which killed SSR (found on real
  workerd, invisible to vite build). Nothing imports Factories, so the chain
  tree-shakes out (server route chunk 1108 -> 792 kB).
- stores: replace the four module-scope createClient() calls (useDraftStore,
  useListStore, useNotificationStore, useUserStore) with a shared lazy
  getSupabaseClient() in helpers/supabase/component.ts — timing-only change,
  required so modules import without env (forkability bar).
- useWorkspaceStore: fixed DEFAULT_PANEL_ID sentinel for the default layout
  (was crypto.randomUUID() at module scope — workerd global-scope violation +
  latent SSR/client hydration mismatch). addPanel still uses random UUIDs.
- docs: unit spec (phase-2-stores-hooks.md) with the audit + empirical findings;
  conventions.md gains the getSupabaseClient + define-allowlist seams;
  strategy.md unit #4 -> in-review.

Verified: web:build + web:typecheck + live typecheck 0; jest 150/150;
/stores-probe SSR 200 on workerd with NO secrets (all 12 selectors render, no
error boundary); client bundle free of secret names; worker 2433 KiB gzip < 3MB
(watch item, noted in spec).

https://claude.ai/code/session_0149rfWzUrf1FBDkKw72Ljpc