### PR TITLE
feat(#754 inbox-search): unit #7 — inbox + search + conversation on TanStack

### DIFF
--- a/docs/migration/phase-2-inbox-search.md
+++ b/docs/migration/phase-2-inbox-search.md
@@ -1,0 +1,115 @@
+# Unit #7 — inbox + search + conversation
+
+> Track B / epic #754. The **second surface-tier unit** — it fans out from `#6 ✅ feeds+profile` (CastRow + react-virtual + the `_app` shell) and **closes #6's one dangling deep-link**: `/conversation/<hash>`, the target of the mobile cast tap AND the legacy `?castHash=` redirect that #6 ported intact. Mounts three more herocast pages — the notifications inbox, the keyword search surface, and the single-cast conversation/thread view — onto the TanStack route tree, **reusing every shared component verbatim** through the unit-#2 `next/*` vite aliases and the unit-#10 `/api/*` worker data routes. Blocked-by: **#6 ✅**. Template: `phase-2-feeds-profile.md`. Reuse contract: `conventions.md`.
+
+## Objective
+
+Render `/inbox`, `/search`, and `/conversation/<hash>` on the TanStack tree with **zero shared-component re-implementation and zero new data-fetching paths**:
+
+1. `/inbox` — the notifications surface (`app/(app)/inbox/page.tsx`, ~1195 LOC): the 5 notification tabs (replies / mentions / likes / recasts / follows) with per-tab cursors + unread badges, the split list/detail pane, `SelectableListWithHotkeys` (`@tanstack/react-virtual`), `CastRow` for the selected/parent cast, auto-refresh + infinite scroll, the full keyboard map (r/q/o/1–5/tab/e/…), and the reply/quote actions that open `NewCastModal`.
+2. `/search` — the keyword search surface (`app/(app)/search/page.tsx`, ~298 LOC): `SearchInterface` (term + filters), `SearchResultsView`, save-as-list, the `?search=`/`?list=` URL bootstrap, and the inline `CastThreadView` when a result is opened. Data via the `useCastSearchInfinite` RQ hook.
+3. `/conversation/<hash>` — the single-cast thread view (`app/conversation/[...slug]/page.tsx` + `app/conversation/layout.tsx`): resolves a cast by hash (or by `<user>/<hash>` → warpcast URL) and renders `CastThreadView` inside `PreviewEmbedContext`. **This is the #6 deep-link target.**
+
+Data already works end-to-end: the `FarcasterProvider` seam (`src/lib/farcaster/providers/neynar.ts`) + the existing RQ/store paths call the unit-#10 `/api/*` worker routes. This unit **reuses them as-is** — no hook/provider/route edits.
+
+- Inbox: `getProvider().getNotifications()` → `/api/notifications`; `getProvider().getCasts()` → `/api/casts` (parent-cast lookup). Plus `useNotificationStore` (read-state, Supabase sync).
+- Search: `useCastSearchInfinite()` → `/api/search`.
+- Conversation: `getProvider().getCastByIdentifier()` → `/api/casts/lookup`; `CastThreadView` internally → `/api/casts/conversation`.
+
+All four routes (`notifications`, `casts`, `search`, `casts/lookup` + the transitive `casts/conversation`) are among unit #10's 19 ✅.
+
+**The load-bearing decision (same as #5/#6): the page *logic* is ported into `src/web/`, but every shared component it renders (`CastRow`, `CastThreadView`, `SelectableListWithHotkeys`, `SearchInterface`, `SearchResultsView`, `PreviewEmbedContext`, the `Embeds/*` tree, the stores, the RQ hook) is consumed VERBATIM.** The only edits to the port vs. the Next source are the surgical, framework-mandated changes (below); the CLAUDE.md layout/virtualization rules hold automatically because the rendered markup is byte-identical to the live app.
+
+## Non-goals
+
+- **No new data layer.** The provider/RQ/store paths + the #10 `/api/*` routes are reused unchanged. No `createServerFn`, no route loaders — inbox/search/conversation fetch client-side exactly as on Next.
+- **No editor work** (#8). Inbox's `r`/`q` (reply/quote) open `NewCastModal`, which lazy-loads `NewCastEditor` via the `next/dynamic` shim (`ssr:false`, stubbed out of the worker bundle in #5). Making the editor *work* is #8; the inbox actions just wire the modal open, as on Next.
+- **No auth/onboarding** (#9). The logged-out states (`Please connect an account…` in inbox; the shell's `/login` client redirect for hydrate routes) are reused as-is.
+- **No DMs** (#12). `/dms` is a separate bucket surface; "inbox" here is notifications only.
+- **No virtualization rewrite.** `SelectableListWithHotkeys` is reused verbatim (the `top`-positioned, `width:100%`/`position:absolute` virtual-item pattern — CLAUDE.md).
+
+## The surgical changes vs. the Next source (everything else is byte-identical)
+
+| # | Next source | Ported `src/web` form | Why |
+|---|-------------|------------------------|-----|
+| C1 | `import { … } from 'next/navigation'` | `import { … } from '@/web/lib/navigation'` | New `src/web` code imports the unit-#2 adapter **directly** (per `conventions.md`), not via the build-alias indirection. Same runtime behavior. (`useRouter`/`useSearchParams` in inbox; `useRouter` in search; `useParams` in conversation.) |
+| C3 | `'use client'` directive (+ the vestigial `/* eslint-disable @next/next/no-img-element */` in search) | removed | Next App-Router-specific directives, inert under TanStack. The search eslint-disable is vestigial (no `<img>` in the file) Next-eslint noise — dropped with `'use client'`. No behavior change. |
+| **C4** | `const slug = params.slug as string[]` (conversation only) | `const slug = ((params._splat as string \| undefined) ?? '').split('/').filter(Boolean)` | **TanStack splat ≠ Next catch-all.** The Next route is `[...slug]` (array param `slug`); the TanStack equivalent is a `$` splat route whose param is `_splat` — a single `"a/b"` string. Rebuilding the segment array keeps `getPayloadFromSlug` + the `slug?.join('/')` effect dep byte-identical. **Behavior-preserving** (both 1-seg `<hash>` and 2-seg `<user>/<hash>` forms still parse). |
+
+> **C2 (the #6 module-scope `createClient()` deferral) does NOT apply here** — none of the three pages create a Supabase client at module scope. The only notable module-scope reads are inbox's pure `parentCastCache = new Map()` / `CACHE_TTL` (no env, no throw) and search's `const APP_FID = process.env.NEXT_PUBLIC_APP_FID!` — left as-is, exactly as #6 left profile's `APP_FID` (`NEXT_PUBLIC_APP_FID` is in the #4 `define` allowlist; unset ⇒ literal `undefined`, no throw).
+>
+> **`next/link` is left as `next/link`** (inbox + conversation). It resolves to `@/web/components/link.tsx` via the unit-#2 build alias (and to real Next types under `tsc`), exactly as the shared components do. The `conventions.md` "Do NOT" list only forbids leaving **`next/navigation`** un-adapted; `next/link`/`next/image`/`next/dynamic` ride the build alias (matching #6, which changed only `next/navigation`).
+
+## Route-tree topology (children added under `_app`)
+
+```
+_app.tsx                       <Home><Outlet/></Home>           (unit #5)
+├── _app.feeds.tsx             /feeds                           (unit #6)
+├── _app.profile.index.tsx     /profile                         (unit #6)
+├── _app.profile.$slug.tsx     /profile/$slug                   (unit #6)
+├── _app.inbox.tsx             /inbox             ← this unit
+├── _app.search.tsx            /search            ← this unit
+└── _app.conversation.$.tsx    /conversation/*    ← this unit (SPLAT, see C4)
+```
+
+`_app.conversation.$.tsx` is a **splat** route (`$` segment → matches `/conversation/<anything>`), the TanStack analogue of the Next `[...slug]` catch-all. The Next `conversation/layout.tsx` wraps children in `<Home>`, so mounting under `_app` (which renders `<Home><Outlet/></Home>`) reproduces the same chrome — no separate layout needed.
+
+**SSR shape (the #5/#6 invariant, restated):** `Home.pageRequiresHydrate` *excludes* `/conversation*` (and `/profile*`, `/analytics*`) but *includes* `/inbox` and `/search`. So:
+- `/inbox` + `/search` SSR the shell's `isHydrated=false` "Loading herocast" gate; content paints after client store hydration + the data fetch. (Correct — do not SSR-hydrate stores.)
+- `/conversation/<hash>` SSRs page content directly, but the page's own `status==='loading'` gate renders the `PageSkeleton` until `getCastByIdentifier` (client) resolves. **So `CastThreadView` → `CastRow` → `VideoEmbed` never renders during SSR**, which keeps the #6 worker-bundle stub (G1) safe on this route too.
+
+The shell lights up correctly by **pathname match** (no shell edits): `getSidebarForPathname` → `/inbox`/`/conversation/` ⇒ `CAST_INFO`, `/search` ⇒ `SEARCH`; `getTitle` → `Conversation` for `/conversation/`; inbox/search nav items already exist in `navigationGroups`.
+
+## Files
+
+- **New (page logic, ported):** `src/web/pages/InboxPage.tsx`, `src/web/pages/SearchPage.tsx`, `src/web/pages/ConversationPage.tsx`.
+- **New (thin routes):** `src/web/routes/_app.inbox.tsx`, `src/web/routes/_app.search.tsx`, `src/web/routes/_app.conversation.$.tsx` — each `createFileRoute('/_app/<path>')({ component })` importing its `pages/` component.
+- **New (this spec):** `docs/migration/phase-2-inbox-search.md`.
+- **Edit (migration-owned):** `docs/migration/strategy.md` (status: #6 → ✅ + PR #768; #7 → 🔍 + PR ref).
+- **Untouched:** `app/`, `pages/`, `next.config.mjs`, `vercel.json`, `src/globals.css`, **`vite.config.mts`** (no new `ssr:false` heavyweight ⇒ no `ssrClientOnlyModules` addition — see G2), and **every shared `src/` file** (CastRow, CastThreadView, SelectableListWithHotkeys, SearchInterface/SearchResultsView, the hooks, the stores, the provider, the navigation adapter). This unit edits nothing outside `src/web/` + the two migration-owned docs.
+
+## Reuse contract (per `conventions.md`)
+
+- **Navigation:** `@/web/lib/navigation` (`useRouter`/`useSearchParams`/`useParams`) — the unit-#2 adapter, imported directly (C1).
+- **Shell mount:** children of the `_app` pathless layout (unit #5) — never re-wrap in `Home`, never re-mount `CommandPalette`/`GlobalHotkeys`.
+- **Data:** the `FarcasterProvider` seam + the existing provider/RQ/store paths → the #10 `/api/*` routes. No new fetch paths.
+- **`define` allowlist:** the ported pages read only `NEXT_PUBLIC_APP_FID` at module scope (already allowlisted, #4). No new public key is read at module scope ⇒ no `define` addition.
+- **Bundle diet:** the `ssrClientOnlyModules` stub (`WalletProviders`, `NewCastEditor`, `VideoEmbed`) already covers everything CastRow/CastThreadView drag. This unit adds no new `ssr:false` module ⇒ no regex change (G2).
+
+## Gotchas (this unit)
+
+- **G1 — TanStack splat vs Next catch-all (C4, load-bearing).** `app/conversation/[...slug]` is a catch-all; its `useParams().slug` is a `string[]`. TanStack's equivalent is the `$` splat route, whose param is `_splat` — a single `/`-joined string, NOT an array, and NOT named `slug`. The unit-#2 `useParams` adapter is a pass-through (it does not transform splat into an array — its `string[]` type union only keeps Next call sites that annotate `string[]` compiling). So the page MUST rebuild the array from `_splat` (C4). Naming the route `_app.conversation.$hash.tsx` (single segment) would have dropped the 2-segment `<user>/<hash>` form — a parity regression; the splat preserves both. Empty splat (`/conversation` with no hash) falls through to the page's existing `not-found` state (graceful; Next's required catch-all would 404 — a benign difference).
+- **G2 — no new worker-bundle risk.** Inbox/conversation mount `CastRow`/`CastThreadView` → `Embeds/index.tsx` → `VideoEmbed`, already stubbed out of the `ssr`/workerd bundle by #6's `ssrClientOnlyModules`. No NEW `ssr:false` heavyweight is introduced (`NewCastModal`→`NewCastEditor` is the #5 stub; search/conversation pull no wallet/editor chunk). Re-checked `web:deploy:dry-run` stays < 3 MB gzip after mounting — see DoD. Only add to the regex if a future `ssr:false` module appears.
+- **G3 — `/conversation` SSRs content; the loading gate keeps `CastThreadView` off the server.** Because `/conversation*` is excluded from `pageRequiresHydrate`, the shell renders page content during SSR. But `ConversationPage` returns the `PageSkeleton` while `status==='loading'` (the initial state; the fetch only runs in a client `useEffect`), so `CastThreadView`/`CastRow`/`VideoEmbed` never execute server-side — the G2 stub's throw is never reached. (Same shape as #6 profile's `<Loading/>` gate.)
+- **G4 — virtualization + layout hold for free.** `SelectableListWithHotkeys` (inbox) is reused verbatim (the `top`-positioned virtual-item pattern), and the pages' `min-h-0`/`flex-1`/`overflow` markup is byte-identical to the live app, so the recurring scroll-container bug class can't regress here.
+- **G5 — route-tree typecheck is generated.** New routes fail `pnpm web:typecheck` (`'/inbox' not assignable to keyof FileRoutesByPath`) until `vite build` regenerates `routeTree.gen.ts`. **Build once, then typecheck** (same as #6/#10).
+- **G6 — INP already wired.** `inp:open-notification` (inbox `selectNotification` → `trackInteractionToPaint`) is in the reused page code; no INP work added here.
+
+## Definition of Done / cf-canary
+
+- [ ] `pnpm web:build` 0 → `pnpm web:typecheck` 0 (after the build regenerates `routeTree.gen.ts`) → live `pnpm typecheck` 0 → `pnpm test` passing.
+- [ ] Routes generated: `/_app/inbox`, `/_app/search`, `/_app/conversation/$` (verified in `routeTree.gen.ts`).
+- [ ] **Worker bundle < 3 MB gzip** (`web:deploy:dry-run`) — expected ≈ #6's 2293 KiB high-water mark (no new `ssr:false` chunk; CastRow/VideoEmbed graph already accounted for in #6).
+- [ ] **No secret VALUE in the client bundle** (#4/#5/#6 invariant holds — no new secret read).
+- [ ] **Real workerd SSR 200** (`pnpm web:serve`, node ≥22): `/inbox`, `/search`, `/conversation/<hash>` all SSR 200 with no import-time throw; `/conversation/<hash>` SSRs the page skeleton (content gated to client).
+- [ ] **Browser canary** (real Chromium on `web:serve`): inbox tabs + virtual list render and recycle on scroll; search interface accepts input and renders results/empty/loading; conversation thread view loads; sidebar/titlebar/nav correct per pathname; no React/hydration/missing-module errors (the Neynar **402 quota passthrough** is expected, not a bug).
+
+> **Neynar quota (HTTP 402):** the dev key is over its monthly CU allocation, so live data returns the quota error (correct passthrough from the #10 routes). The DoD is **forkability + render-path** focused; full real-data parity (real notifications/search results/threads through the components, virtual scroll over a long real list) needs a **fresh quota'd `NEYNAR_API_KEY`** in `.dev.vars` — re-run the browser canary then, or verify post-`web:deploy`. Treat 402 as "needs a quota'd key", not a bug. (Shared open item with #6/#10.)
+
+## Follow-ups surfaced (not fixed here)
+
+- **[#8] Editor actions** (inbox reply/quote) open `NewCastModal` but the editor itself is the #8 port; until then the modal renders the lazy stub's loading state on the canary.
+- **[deploy] Real-data canary** needs a quota'd Neynar key — the DoD items that can't be green locally on the over-quota dev key (shared with #6/#10).
+- **[CI] gzip budget + secret-VALUE grep** — the standing #0/#5/#6/#10 ask (assert a gzip budget + an `/api/health` smoke in the #0 prebuild; switch the secret invariant to grep VALUES not names) still stands; unchanged by this unit.
+- **[#13] No new probes** — the three pages are the real surface; the cutover delete list is unchanged.
+
+## Tier-1 review (ran — clean)
+
+A dynamic multi-agent review workflow on this unit's diff, **4 dimensions** (parity / ssr-bundle / conventions / correctness), each finding adversarially verified by an independent skeptic prompted to refute it: **0 raw findings, 0 confirmed** across all four. Specifically confirmed:
+
+- **parity** — the three ported pages are byte-identical to their Next sources except the documented C1/C3/C4 surgical changes; no dropped/added logic, JSX, effect deps, hotkeys, or data calls. The C4 slug rebuild is behavior-preserving vs `params.slug as string[]`.
+- **ssr-bundle** — no module-scope throw on workerd (inbox's `parentCastCache`/`CACHE_TTL` are pure; search's `APP_FID` read is `define`-allowlisted), no new secret read, no new `ssr:false` heavyweight (CastRow→Embeds→VideoEmbed already stubbed by #6).
+- **conventions** — diff touches only `src/web/**` + the two migration-owned docs (route tree is gitignored/generated); navigation via `@/web/lib/navigation`; no `Home` re-wrap / palette re-mount; no new data path; thin routes match the `_app.feeds.tsx` pattern with correct `createFileRoute` ids.
+- **correctness** — `_app.conversation.$.tsx` is the splat analogue of the Next `[...slug]` catch-all and serves both 1-seg and 2-seg forms; the `_splat`→array rebuild matches Next semantics for empty/1-seg/2-seg; the page reads `params._splat`; route wiring + default-import are correct; no new render loop.
+
+(Tier-2 codex integration review runs at the surface-tier boundary after #6–#9 — not in this unit.)

--- a/docs/migration/strategy.md
+++ b/docs/migration/strategy.md
@@ -33,7 +33,7 @@ Sizes leveled (S/M/L, none >~2× another). Status: ☐ todo · ◐ in-progress �
 | 4 | port: stores + RQ hooks SSR-safety pass | S–M | ✅ | 3 | `phase-2-stores-hooks.md` |
 | 5 | port: app shell + sidebar + command palette | L | ✅ | 2,3,4 | `phase-2-shell.md` (PR #766) |
 | 6 | port: feeds + profile (CastRow + react-virtual) | L | ✅ | 5 | `phase-2-feeds-profile.md` (PR #768) |
-| 7 | port: inbox + search + conversation | M–L | 🔍 | 6 | `phase-2-inbox-search.md` |
+| 7 | port: inbox + search + conversation | M–L | 🔍 | 6 | `phase-2-inbox-search.md` (PR #769) |
 | 8 | port: editor (TipTap) + embeds | L | ☐ | 3,5 | `phase-2-editor.md` |
 | 9 | port: auth + accounts + onboarding (OAuth write) | L | ☐ | 3,5 | `phase-2-auth-accounts.md` |
 | 10 | port: data API routes behind FarcasterProvider (~19) | L | ✅ | 0,4 | `phase-3-data-routes.md` (PR #767) |

--- a/docs/migration/strategy.md
+++ b/docs/migration/strategy.md
@@ -32,8 +32,8 @@ Sizes leveled (S/M/L, none >~2× another). Status: ☐ todo · ◐ in-progress �
 | 3 | port: provider tree (wallet/posthog/persist/auth ctx) | L | ✅ | 2 | `phase-2-providers.md` |
 | 4 | port: stores + RQ hooks SSR-safety pass | S–M | ✅ | 3 | `phase-2-stores-hooks.md` |
 | 5 | port: app shell + sidebar + command palette | L | ✅ | 2,3,4 | `phase-2-shell.md` (PR #766) |
-| 6 | port: feeds + profile (CastRow + react-virtual) | L | 🔍 | 5 | `phase-2-feeds-profile.md` (PR #768) |
-| 7 | port: inbox + search + conversation | M–L | ☐ | 6 | `phase-2-inbox-search.md` |
+| 6 | port: feeds + profile (CastRow + react-virtual) | L | ✅ | 5 | `phase-2-feeds-profile.md` (PR #768) |
+| 7 | port: inbox + search + conversation | M–L | 🔍 | 6 | `phase-2-inbox-search.md` |
 | 8 | port: editor (TipTap) + embeds | L | ☐ | 3,5 | `phase-2-editor.md` |
 | 9 | port: auth + accounts + onboarding (OAuth write) | L | ☐ | 3,5 | `phase-2-auth-accounts.md` |
 | 10 | port: data API routes behind FarcasterProvider (~19) | L | ✅ | 0,4 | `phase-3-data-routes.md` (PR #767) |

--- a/src/web/pages/ConversationPage.tsx
+++ b/src/web/pages/ConversationPage.tsx
@@ -1,0 +1,128 @@
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { CastThreadView } from '@/common/components/CastThreadView';
+import { PreviewEmbedContext } from '@/common/components/Feed/PreviewEmbedContext';
+import { PageSkeleton } from '@/common/components/PageSkeleton';
+import type { FarcasterCast } from '@/common/types/farcaster';
+import { Button } from '@/components/ui/button';
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { getProvider } from '@/lib/farcaster/providers';
+import { useNavigationStore } from '@/stores/useNavigationStore';
+import { useParams } from '@/web/lib/navigation';
+
+type LoadStatus = 'loading' | 'loaded' | 'not-found';
+
+const PREVIEW_CONTEXT_VALUE = { inPreview: true };
+
+export default function ConversationPage() {
+  // C4 (route-semantics): the Next source is a `[...slug]` catch-all whose `useParams()`
+  // yields `slug: string[]`. TanStack models the same catch-all as a `$` splat route
+  // (`_app.conversation.$.tsx`), whose param arrives as `_splat` — a single "a/b" string.
+  // Rebuild the Next-shaped segment array from it so the rest of the page is byte-identical
+  // (`getPayloadFromSlug` + the `slug?.join('/')` effect dep are unchanged).
+  const params = useParams();
+  const slug = ((params._splat as string | undefined) ?? '').split('/').filter(Boolean);
+  const [cast, setCast] = useState<FarcasterCast | null>(null);
+  const [status, setStatus] = useState<LoadStatus>('loading');
+  const { updateSelectedCast } = useNavigationStore();
+
+  useEffect(() => {
+    return () => {
+      updateSelectedCast();
+    };
+  }, [updateSelectedCast]);
+
+  function getPayloadFromSlug(): { identifier: string; type: 'hash' | 'url' } | null {
+    if (!slug || slug.length === 0) return null;
+    if (slug.length === 1) {
+      if (!slug[0].startsWith('0x')) return null;
+      return { identifier: slug[0], type: 'hash' };
+    }
+    if (slug.length === 2) {
+      if (!slug[1].startsWith('0x')) return null;
+      return { identifier: `https://warpcast.com/${slug[0]}/${slug[1]}`, type: 'url' };
+    }
+    return null;
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const getData = async () => {
+      const payload = getPayloadFromSlug();
+      if (!payload) {
+        setStatus('not-found');
+        return;
+      }
+
+      setCast(null);
+      updateSelectedCast();
+      setStatus('loading');
+
+      try {
+        const cast = await getProvider().getCastByIdentifier({
+          identifier: payload.identifier,
+          type: payload.type,
+        });
+        if (cancelled) return;
+        setCast(cast);
+        updateSelectedCast(cast);
+        setStatus('loaded');
+      } catch (err) {
+        if (cancelled) return;
+        console.error(`Error in conversation page: ${err} ${slug}`);
+        setStatus('not-found');
+      }
+    };
+
+    getData();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slug?.join('/')]);
+
+  if (status === 'loading') {
+    return (
+      <div className="h-full w-full overflow-y-auto">
+        <div className="mx-auto w-full max-w-3xl px-4 py-6" data-testid="conversation-loading">
+          <PageSkeleton variant="profile" />
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'not-found' || !cast) {
+    return (
+      <div className="h-full w-full overflow-y-auto">
+        <div className="mx-auto w-full max-w-3xl px-4 py-12 flex justify-center">
+          <Card className="w-full max-w-md" data-testid="conversation-not-found">
+            <CardHeader>
+              <CardTitle>Cast not found</CardTitle>
+              <CardDescription>
+                We couldn&apos;t find a cast at that link. It may have been deleted or the URL may be incorrect.
+              </CardDescription>
+            </CardHeader>
+            <CardFooter>
+              <Link href="/feeds" className="w-full">
+                <Button className="w-full">Back to feeds</Button>
+              </Link>
+            </CardFooter>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    // PreviewEmbedContext flips EmbedList over to the smart-group
+    // MultiEmbedStack renderer (matching the /feeds preview pane) so the
+    // thread view renders embeds the same way users see them in the feed.
+    <PreviewEmbedContext.Provider value={PREVIEW_CONTEXT_VALUE}>
+      <div className="h-full w-full">
+        <CastThreadView cast={cast} containerHeight="100%" />
+      </div>
+    </PreviewEmbedContext.Provider>
+  );
+}

--- a/src/web/pages/InboxPage.tsx
+++ b/src/web/pages/InboxPage.tsx
@@ -1,0 +1,1193 @@
+import { formatDistanceToNowStrict } from 'date-fns';
+import isEmpty from 'lodash.isempty';
+import { Cloud, MoreHorizontal, RefreshCw } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { CastRow } from '@/common/components/CastRow';
+import { Loading } from '@/common/components/Loading';
+import { SelectableListWithHotkeys } from '@/common/components/SelectableListWithHotkeys';
+import SkeletonCastRow from '@/common/components/SkeletonCastRow';
+import { createParentCastId } from '@/common/constants/farcaster';
+import { HotkeyScopes } from '@/common/constants/hotkeys';
+import { formatLargeNumber } from '@/common/helpers/text';
+import { type FarcasterCast, type FarcasterNotification, NotificationType } from '@/common/types/farcaster';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { KbdTooltip } from '@/components/ui/kbd';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { getProvider } from '@/lib/farcaster/providers';
+import { cn } from '@/lib/utils';
+import { useAccountStore } from '@/stores/useAccountStore';
+import { useDraftStore } from '@/stores/useDraftStore';
+import { CastModalView, useNavigationStore } from '@/stores/useNavigationStore';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+import { trackInteractionToPaint } from '@/stores/usePerformanceStore';
+import { useRouter, useSearchParams } from '@/web/lib/navigation';
+
+// Client-side cache for parent casts (prevents repeated API calls)
+const parentCastCache = new Map<string, { cast: FarcasterCast | null; timestamp: number }>();
+const CACHE_TTL = 24 * 60 * 60 * 1000; // 1 day
+
+enum NotificationTab {
+  mentions = 'mentions',
+  replies = 'replies',
+  likes = 'likes',
+  recasts = 'recasts',
+  follows = 'follows',
+}
+
+const notificationTabToType = (tab: NotificationTab) => {
+  switch (tab) {
+    case NotificationTab.mentions:
+      return NotificationType.Mention;
+    case NotificationTab.likes:
+      return NotificationType.Likes;
+    case NotificationTab.follows:
+      return NotificationType.Follows;
+    case NotificationTab.replies:
+      return NotificationType.Reply;
+    case NotificationTab.recasts:
+      return NotificationType.Recasts;
+    default:
+      return undefined;
+  }
+};
+
+// Map notification tab to API type string
+const notificationTabToApiType = (tab: NotificationTab): string | undefined => {
+  switch (tab) {
+    case NotificationTab.mentions:
+      return 'mentions';
+    case NotificationTab.likes:
+      return 'likes';
+    case NotificationTab.follows:
+      return 'follows';
+    case NotificationTab.replies:
+      return 'replies';
+    case NotificationTab.recasts:
+      return 'recasts';
+    default:
+      return undefined;
+  }
+};
+
+// Compact follower profile component for follow notifications
+const CompactFollowerProfile = ({ user, viewerFid }: { user: any; viewerFid: string }) => {
+  return (
+    <Link href={`/profile/${user.username}`} prefetch={false}>
+      <div className="flex items-start gap-3 p-3 hover:bg-muted/50 rounded-lg border border-muted/30 transition-colors">
+        <Avatar className="h-10 w-10 flex-shrink-0">
+          <AvatarImage src={user.pfp_url} />
+          <AvatarFallback>{user.username?.slice(0, 2)}</AvatarFallback>
+        </Avatar>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm text-foreground truncate">{user.display_name}</span>
+            {user.power_badge && <img src="/images/ActiveBadge.webp" className="h-3.5 w-3.5" alt="Power badge" />}
+          </div>
+          <div className="text-xs text-foreground/60 truncate">@{user.username}</div>
+          {user.profile?.bio?.text && (
+            <p className="text-xs text-foreground/70 mt-1 line-clamp-2 break-words">{user.profile.bio.text}</p>
+          )}
+          <div className="flex gap-3 mt-1 text-xs text-foreground/60">
+            <span>{formatLargeNumber(user.follower_count || 0)} followers</span>
+            <span>{formatLargeNumber(user.following_count || 0)} following</span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+const Inbox = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isNewCastModalOpen, setCastModalView, openNewCastModal, setCastModalDraftId, updateSelectedCast } =
+    useNavigationStore();
+  const { addNewPostDraft } = useDraftStore();
+  const selectedAccount = useAccountStore((state) => state.accounts[state.selectedAccountIdx]);
+  const { isRead, markAsRead, markAsUnread, getUnreadCount } = useNotificationStore();
+  const [notificationsByType, setNotificationsByType] = useState<Record<NotificationTab, FarcasterNotification[]>>({
+    [NotificationTab.replies]: [],
+    [NotificationTab.mentions]: [],
+    [NotificationTab.likes]: [],
+    [NotificationTab.recasts]: [],
+    [NotificationTab.follows]: [],
+  });
+  const cursorsByType = useRef<Record<NotificationTab, string | undefined>>({
+    [NotificationTab.replies]: undefined,
+    [NotificationTab.mentions]: undefined,
+    [NotificationTab.likes]: undefined,
+    [NotificationTab.recasts]: undefined,
+    [NotificationTab.follows]: undefined,
+  });
+  const [loadingByType, setLoadingByType] = useState<Record<NotificationTab, boolean>>({
+    [NotificationTab.replies]: false,
+    [NotificationTab.mentions]: false,
+    [NotificationTab.likes]: false,
+    [NotificationTab.recasts]: false,
+    [NotificationTab.follows]: false,
+  });
+  const [selectedNotificationIdx, setSelectedNotificationIdx] = useState<number>(0);
+  const [activeTab, setActiveTab] = useState<NotificationTab>(NotificationTab.replies);
+  const [parentCast, setParentCast] = useState<FarcasterCast | null>(null);
+  const [isLoadingParent, setIsLoadingParent] = useState<boolean>(false);
+  const [lastAutoLoadTime, setLastAutoLoadTime] = useState<number>(0);
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  const viewerFid = useAccountStore((state) => state.accounts[state.selectedAccountIdx]?.platformAccountId);
+
+  // Get current notifications for active tab
+  const notifications = notificationsByType[activeTab];
+
+  // Generate unique ID for notification (pure over its argument — memoized so the
+  // callbacks/effect that depend on it stay stable across renders)
+  const getNotificationId = useCallback((notification: FarcasterNotification): string => {
+    if (notification.type === NotificationType.Follows && notification.follows) {
+      // For follows, use the first follower's fid + timestamp
+      return `follow-${notification.follows[0]?.user?.fid}-${notification.most_recent_timestamp}`;
+    }
+    // For other types, use cast hash + type + timestamp
+    return `${notification.cast?.hash || 'unknown'}-${notification.type}-${notification.most_recent_timestamp}`;
+  }, []);
+
+  // Optimistically flip read-state for the notification at idx (no-op if already read)
+  const markNotificationReadAt = useCallback(
+    (idx: number) => {
+      const notification = notifications[idx];
+      if (!notification) return;
+      const notificationId = getNotificationId(notification);
+      if (!isRead(notificationId)) {
+        markAsRead(notificationId, activeTab);
+      }
+    },
+    [notifications, isRead, markAsRead, getNotificationId, activeTab]
+  );
+
+  // Select a notification and flip its read-state in the same tick, so the unread dot +
+  // tab badge clear on the same paint as the selection highlight (tap → paint < 16ms).
+  const selectNotification = useCallback(
+    (idx: number) => {
+      trackInteractionToPaint('open-notification', 100);
+      setSelectedNotificationIdx(idx);
+      markNotificationReadAt(idx);
+    },
+    [markNotificationReadAt]
+  );
+
+  const isLoading = loadingByType[activeTab] || false;
+  const loadMoreCursor = cursorsByType.current[activeTab];
+
+  const fetchNotifications = useCallback(
+    async (tab: NotificationTab, reset = false, limit = 25) => {
+      if (!viewerFid) return;
+
+      // Set loading state for this specific tab
+      setLoadingByType((prev) => ({ ...prev, [tab]: true }));
+
+      try {
+        const result = await getProvider().getNotifications({
+          fid: Number(viewerFid),
+          limit,
+          type: notificationTabToApiType(tab),
+          cursor: !reset ? cursorsByType.current[tab] : undefined,
+        });
+
+        if (result.notifications) {
+          // Update notifications for this specific tab
+          setNotificationsByType((prev) => ({
+            ...prev,
+            [tab]: reset ? result.notifications : [...prev[tab], ...result.notifications],
+          }));
+
+          // Update cursor for this tab
+          cursorsByType.current[tab] = result.next?.cursor;
+        }
+
+        return result.notifications || [];
+      } catch (error) {
+        console.error(`Error fetching notifications for ${tab}:`, error);
+        return [];
+      } finally {
+        setLoadingByType((prev) => ({ ...prev, [tab]: false }));
+      }
+    },
+    [viewerFid]
+  );
+
+  const changeTab = useCallback(
+    async (tab: NotificationTab) => {
+      setActiveTab(tab);
+      setSelectedNotificationIdx(0);
+      setParentCast(null);
+
+      // If this tab has no notifications loaded yet, fetch them
+      if (notificationsByType[tab].length === 0 && !loadingByType[tab]) {
+        await fetchNotifications(tab, true, 25);
+      }
+    },
+    [notificationsByType, loadingByType, fetchNotifications]
+  );
+
+  const fetchParentCast = useCallback(
+    async (parentHash: string) => {
+      if (!viewerFid || !parentHash) return;
+
+      // Check client-side cache first
+      const cacheKey = `${parentHash}:${viewerFid}`;
+      const cached = parentCastCache.get(cacheKey);
+
+      if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+        console.log(`Client cache hit for parent cast: ${parentHash.substring(0, 10)}...`);
+        setParentCast(cached.cast);
+        return;
+      }
+
+      // Remove expired cache entry
+      if (cached) {
+        parentCastCache.delete(cacheKey);
+      }
+
+      setIsLoadingParent(true);
+      try {
+        console.log(`Fetching parent cast: ${parentHash.substring(0, 10)}...`);
+        const casts = await getProvider().getCasts({
+          hashes: [parentHash],
+          viewerFid: Number(viewerFid),
+        });
+
+        if (casts.length > 0) {
+          const cast = casts[0];
+          setParentCast(cast);
+          parentCastCache.set(cacheKey, { cast, timestamp: Date.now() });
+        } else {
+          setParentCast(null);
+          // Cache "not found" to prevent infinite retry loops for deleted casts
+          parentCastCache.set(cacheKey, { cast: null, timestamp: Date.now() });
+        }
+
+        // Clean up expired cache entries periodically
+        if (parentCastCache.size > 1000) {
+          const now = Date.now();
+          for (const [k, v] of parentCastCache.entries()) {
+            if (now - v.timestamp > CACHE_TTL) {
+              parentCastCache.delete(k);
+            }
+          }
+        }
+      } catch (error) {
+        console.error('Error fetching parent cast:', error);
+        setParentCast(null);
+      } finally {
+        setIsLoadingParent(false);
+      }
+    },
+    [viewerFid]
+  );
+
+  // Handle URL query parameter for tab switching
+  useEffect(() => {
+    const tab = searchParams.get('tab');
+    if (tab && typeof tab === 'string') {
+      // Validate the tab value is a valid NotificationTab
+      const validTabs = Object.values(NotificationTab);
+      if (validTabs.includes(tab as NotificationTab)) {
+        const newTab = tab as NotificationTab;
+        console.log(`📍 Switching to ${newTab} tab from URL query`);
+        changeTab(newTab);
+      }
+    }
+  }, [searchParams, changeTab]);
+
+  // Initial load and account changes
+  useEffect(() => {
+    if (!viewerFid) return;
+
+    // Reset state immediately
+    setSelectedNotificationIdx(0);
+    setParentCast(null);
+    setNotificationsByType({
+      [NotificationTab.replies]: [],
+      [NotificationTab.mentions]: [],
+      [NotificationTab.likes]: [],
+      [NotificationTab.recasts]: [],
+      [NotificationTab.follows]: [],
+    });
+    cursorsByType.current = {
+      [NotificationTab.replies]: undefined,
+      [NotificationTab.mentions]: undefined,
+      [NotificationTab.likes]: undefined,
+      [NotificationTab.recasts]: undefined,
+      [NotificationTab.follows]: undefined,
+    };
+
+    // Load notifications for the active tab
+    console.log(`🚀 Loading notifications for ${activeTab} tab...`);
+    fetchNotifications(activeTab, true, 25);
+  }, [viewerFid, activeTab, fetchNotifications]);
+
+  // Auto-refresh every 2 minutes for active tab
+  useEffect(() => {
+    if (!viewerFid) return;
+
+    const intervalId = setInterval(
+      () => {
+        fetchNotifications(activeTab, true, 20); // Refresh active tab
+      },
+      2 * 60 * 1000
+    );
+
+    return () => clearInterval(intervalId);
+  }, [viewerFid, activeTab, fetchNotifications]);
+
+  // Update selected cast and fetch parent when notification selection changes
+  useEffect(() => {
+    // If notifications are empty (after refresh or on initial load), clear the selected cast
+    if (isEmpty(notifications)) {
+      updateSelectedCast(undefined);
+      setParentCast(null);
+      return;
+    }
+
+    // Don't process selection changes while loading to prevent jittery effect
+    if (loadingByType[activeTab] || selectedNotificationIdx < 0) {
+      return;
+    }
+
+    const notification = notifications[selectedNotificationIdx];
+    if (!notification) return;
+
+    // Mark as read on selection (covers initial load + programmatic selection;
+    // interactive paths already flip synchronously via selectNotification)
+    markNotificationReadAt(selectedNotificationIdx);
+
+    // Only update selected cast if the notification has a cast (not for follows)
+    if (notification?.cast) {
+      updateSelectedCast(notification.cast);
+
+      // For replies and mentions, fetch the parent cast (only if we don't have it already)
+      if (
+        (notification.type === NotificationType.Reply || notification.type === NotificationType.Mention) &&
+        notification.cast.parent_hash
+      ) {
+        // Check if we already have this parent cast to prevent repeated requests
+        const currentParentHash = notification.cast.parent_hash;
+        if (parentCast?.hash !== currentParentHash) {
+          // Add a small delay to prevent rapid-fire requests during navigation
+          const timeoutId = setTimeout(() => {
+            fetchParentCast(currentParentHash);
+          }, 150); // Increased delay to reduce jitter
+
+          return () => clearTimeout(timeoutId);
+        }
+      } else {
+        setParentCast(null);
+      }
+    } else {
+      // Clear selected cast for follow notifications
+      updateSelectedCast(undefined);
+      setParentCast(null);
+    }
+  }, [
+    notifications,
+    selectedNotificationIdx,
+    parentCast?.hash,
+    loadingByType,
+    activeTab,
+    markNotificationReadAt,
+    updateSelectedCast,
+  ]);
+
+  // Reset selection when tab changes
+  useEffect(() => {
+    setSelectedNotificationIdx(0);
+  }, [activeTab]);
+
+  // Scroll to top when tab changes
+  useEffect(() => {
+    if (listContainerRef.current) {
+      // Find the scrollable container created by SelectableListWithHotkeys
+      const scrollableElement = listContainerRef.current.querySelector('.overflow-y-auto');
+      if (scrollableElement) {
+        scrollableElement.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    }
+  }, [activeTab]);
+
+  // Cleanup effect to ensure hotkeys are properly removed on unmount
+  useEffect(() => {
+    return () => {
+      // Clear any pending timeouts and reset state
+      setParentCast(null);
+      setIsLoadingParent(false);
+      updateSelectedCast(undefined);
+    };
+  }, []);
+
+  // Stable callback functions for hotkeys to prevent them from breaking
+  const onReply = useCallback(() => {
+    console.log('🔥 Reply hotkey pressed!', {
+      selectedNotificationIdx,
+      notificationsLength: notifications.length,
+      isNewCastModalOpen,
+    });
+
+    if (selectedNotificationIdx >= 0 && notifications.length > selectedNotificationIdx) {
+      const notification = notifications[selectedNotificationIdx];
+      console.log('📬 Selected notification:', notification);
+
+      if (notification?.cast) {
+        console.log('📝 Creating reply draft for cast:', notification.cast.hash);
+        setCastModalView(CastModalView.Reply);
+        updateSelectedCast(notification.cast);
+        addNewPostDraft({
+          parentCastId: createParentCastId(notification.cast.author.fid, notification.cast.hash, 'inbox.replyHotkey'),
+          onSuccess(draftId) {
+            console.log('✅ Draft created successfully:', draftId);
+            setCastModalDraftId(draftId);
+            openNewCastModal();
+          },
+        });
+      } else {
+        console.log('❌ No cast found in notification');
+      }
+    } else {
+      console.log('❌ Invalid notification index or empty notifications');
+    }
+  }, [
+    selectedNotificationIdx,
+    notifications,
+    setCastModalView,
+    updateSelectedCast,
+    addNewPostDraft,
+    setCastModalDraftId,
+    openNewCastModal,
+    isNewCastModalOpen,
+  ]);
+
+  const onQuote = useCallback(() => {
+    console.log('🔥 Quote hotkey pressed!', {
+      selectedNotificationIdx,
+      notificationsLength: notifications.length,
+      isNewCastModalOpen,
+    });
+
+    if (selectedNotificationIdx >= 0 && notifications.length > selectedNotificationIdx) {
+      const notification = notifications[selectedNotificationIdx];
+      console.log('📬 Selected notification:', notification);
+
+      if (notification?.cast) {
+        console.log('💬 Creating quote draft for cast:', notification.cast.hash);
+        setCastModalView(CastModalView.Quote);
+        updateSelectedCast(notification.cast);
+        addNewPostDraft({
+          embeds: [
+            {
+              castId: {
+                hash: notification.cast.hash as any,
+                fid: notification.cast.author.fid as any,
+              },
+            },
+          ],
+          onSuccess(draftId) {
+            console.log('✅ Quote draft created successfully:', draftId);
+            setCastModalDraftId(draftId);
+            openNewCastModal();
+          },
+        });
+      } else {
+        console.log('❌ No cast found in notification');
+      }
+    } else {
+      console.log('❌ Invalid notification index or empty notifications');
+    }
+  }, [
+    selectedNotificationIdx,
+    notifications,
+    setCastModalView,
+    updateSelectedCast,
+    addNewPostDraft,
+    setCastModalDraftId,
+    openNewCastModal,
+    isNewCastModalOpen,
+  ]);
+
+  const onSelect = useCallback(() => {
+    if (selectedNotificationIdx >= 0 && notifications.length > selectedNotificationIdx) {
+      const notification = notifications[selectedNotificationIdx];
+      if (notification) {
+        // For follow notifications, navigate to the first follower's profile
+        if (notification.type === NotificationType.Follows && notification.follows && notification.follows.length > 0) {
+          const firstFollower = notification.follows[0]?.user;
+          router.push(`/profile/${firstFollower.username}`);
+        }
+        // For other notifications with casts, navigate to the conversation
+        else if (notification.cast) {
+          router.push(`/conversation/${notification.cast.hash}`);
+        }
+      }
+    }
+  }, [selectedNotificationIdx, notifications, router]);
+
+  // Stable tab switching callbacks to prevent hotkey breaking
+  const switchToReplies = useCallback(() => changeTab(NotificationTab.replies), [changeTab]);
+  const switchToMentions = useCallback(() => changeTab(NotificationTab.mentions), [changeTab]);
+  const switchToLikes = useCallback(() => changeTab(NotificationTab.likes), [changeTab]);
+  const switchToRecasts = useCallback(() => changeTab(NotificationTab.recasts), [changeTab]);
+  const switchToFollows = useCallback(() => changeTab(NotificationTab.follows), [changeTab]);
+  const refreshNotifications = useCallback(async () => {
+    // Clear all state before refresh
+    setParentCast(null);
+    updateSelectedCast(undefined);
+    setSelectedNotificationIdx(0);
+
+    // Clear notifications for current tab to show loading state
+    setNotificationsByType((prev) => ({
+      ...prev,
+      [activeTab]: [],
+    }));
+
+    // Fetch fresh notifications
+    await fetchNotifications(activeTab, true, 25);
+  }, [fetchNotifications, activeTab, updateSelectedCast]);
+  const loadMoreNotifications = useCallback(() => {
+    if (cursorsByType.current[activeTab] && !loadingByType[activeTab]) {
+      fetchNotifications(activeTab, false, 25);
+    }
+  }, [activeTab, loadingByType, fetchNotifications]);
+
+  // Auto-load when scrolling near bottom with safeguards
+  const handleScroll = useCallback(
+    (event: Event) => {
+      const container = event.target as HTMLElement;
+      if (!container || !cursorsByType.current[activeTab] || loadingByType[activeTab]) return;
+
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const scrollPercentage = (scrollTop + clientHeight) / scrollHeight;
+
+      // Trigger when 85% scrolled (earlier trigger) and prevent rapid requests
+      const now = Date.now();
+      const timeSinceLastLoad = now - lastAutoLoadTime;
+
+      if (scrollPercentage > 0.85 && timeSinceLastLoad > 1500) {
+        // 1.5 second throttle, 85% trigger
+        console.log(`🔄 Auto-loading more notifications (${(scrollPercentage * 100).toFixed(1)}% scrolled)`);
+        setLastAutoLoadTime(now);
+        fetchNotifications(activeTab, false, 25);
+      }
+    },
+    [activeTab, loadingByType, lastAutoLoadTime, fetchNotifications]
+  );
+
+  // Attach scroll listener to the actual scrollable element inside SelectableListWithHotkeys
+  useEffect(() => {
+    const container = listContainerRef.current;
+    if (!container) return;
+
+    // Find the scrollable element (it's usually the first child with overflow-y-auto)
+    const scrollableElement = container.querySelector('[style*="overflow-y: auto"], .overflow-y-auto');
+    if (!scrollableElement) {
+      console.warn('Could not find scrollable element for auto-load');
+      return;
+    }
+
+    console.log('📜 Attached scroll listener to:', scrollableElement.className);
+    scrollableElement.addEventListener('scroll', handleScroll, { passive: true });
+    return () => scrollableElement.removeEventListener('scroll', handleScroll);
+  }, [handleScroll, notifications.length]); // Re-attach when notifications change
+
+  // Smart auto-load for sparse tabs (handles edge case of few notifications)
+  useEffect(() => {
+    // If we have very few notifications (1-3) but there's more data available, auto-load
+    const shouldAutoLoad =
+      notifications.length > 0 &&
+      notifications.length <= 3 &&
+      cursorsByType.current[activeTab] &&
+      !loadingByType[activeTab];
+
+    if (shouldAutoLoad) {
+      const now = Date.now();
+      const timeSinceLastLoad = now - lastAutoLoadTime;
+
+      // Only auto-load if we haven't done it recently (prevent infinite loops)
+      if (timeSinceLastLoad > 5000) {
+        // 5 second throttle for sparse auto-loading
+        console.log(
+          `📈 Sparse tab auto-load: ${activeTab} has only ${notifications.length} notifications, loading more...`
+        );
+        setLastAutoLoadTime(now);
+        fetchNotifications(activeTab, false, 25);
+      }
+    }
+  }, [notifications, activeTab, loadingByType, lastAutoLoadTime, fetchNotifications]);
+
+  // Tab cycling functions
+  const tabOrder = [
+    NotificationTab.replies,
+    NotificationTab.mentions,
+    NotificationTab.likes,
+    NotificationTab.recasts,
+    NotificationTab.follows,
+  ];
+
+  const cycleToNextTab = useCallback(() => {
+    const currentIndex = tabOrder.indexOf(activeTab);
+    const nextIndex = (currentIndex + 1) % tabOrder.length;
+    changeTab(tabOrder[nextIndex]);
+    console.log(`🔄 Tab navigation: ${activeTab} → ${tabOrder[nextIndex]}`);
+  }, [activeTab, changeTab]);
+
+  const cycleToPrevTab = useCallback(() => {
+    const currentIndex = tabOrder.indexOf(activeTab);
+    const prevIndex = currentIndex === 0 ? tabOrder.length - 1 : currentIndex - 1;
+    changeTab(tabOrder[prevIndex]);
+    console.log(`🔄 Shift+Tab navigation: ${activeTab} → ${tabOrder[prevIndex]}`);
+  }, [activeTab, changeTab]);
+
+  // Mark selected notification as read
+  const markSelectedAsRead = useCallback(() => {
+    if (selectedNotificationIdx >= 0 && notifications.length > selectedNotificationIdx) {
+      const notification = notifications[selectedNotificationIdx];
+      const notificationId = getNotificationId(notification);
+
+      // Always mark as read, even if already read
+      markAsRead(notificationId, activeTab);
+    }
+  }, [selectedNotificationIdx, notifications, markAsRead, getNotificationId, activeTab]);
+
+  // Keyboard shortcuts with proper dependency arrays and stable callbacks
+  useHotkeys(
+    'r',
+    onReply,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      preventDefault: true,
+      enableOnContentEditable: false,
+    },
+    [onReply]
+  );
+
+  // Note: Removed debug logging to reduce console noise and potential jitter
+
+  useHotkeys(
+    'q',
+    onQuote,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      preventDefault: true,
+      enableOnContentEditable: false,
+    },
+    [onQuote]
+  );
+
+  useHotkeys(
+    ['o', 'enter'],
+    onSelect,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      preventDefault: true,
+      enableOnContentEditable: false,
+    },
+    [onSelect]
+  );
+
+  // Tab switching shortcuts with stable callbacks
+  useHotkeys(
+    '1',
+    switchToReplies,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    },
+    [switchToReplies]
+  );
+
+  useHotkeys(
+    '2',
+    switchToMentions,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    },
+    [switchToMentions]
+  );
+
+  useHotkeys(
+    '3',
+    switchToLikes,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    },
+    [switchToLikes]
+  );
+
+  useHotkeys(
+    '4',
+    switchToRecasts,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    },
+    [switchToRecasts]
+  );
+
+  useHotkeys(
+    '5',
+    switchToFollows,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    },
+    [switchToFollows]
+  );
+
+  // Refresh shortcut
+  useHotkeys(
+    'shift+r',
+    refreshNotifications,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    },
+    [refreshNotifications]
+  );
+
+  // Load more shortcut for power users
+  useHotkeys(
+    'shift+l',
+    loadMoreNotifications,
+    {
+      enabled: !isNewCastModalOpen && !!cursorsByType.current[activeTab],
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+    },
+    [loadMoreNotifications, activeTab]
+  );
+
+  // Tab cycling shortcuts
+  useHotkeys(
+    'tab',
+    cycleToNextTab,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+      preventDefault: true,
+    },
+    [cycleToNextTab]
+  );
+
+  useHotkeys(
+    'shift+tab',
+    cycleToPrevTab,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+      preventDefault: true,
+    },
+    [cycleToPrevTab]
+  );
+
+  // Mark as read
+  useHotkeys(
+    'e',
+    markSelectedAsRead,
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+      preventDefault: true,
+    },
+    [markSelectedAsRead]
+  );
+
+  // Mark all as read
+  useHotkeys(
+    'alt+e',
+    () => {
+      const notificationIds = notifications.map(getNotificationId);
+      useNotificationStore.getState().markAllAsRead(activeTab, notificationIds);
+    },
+    {
+      enabled: !isNewCastModalOpen,
+      enableOnFormTags: false,
+      enableOnContentEditable: false,
+      preventDefault: true,
+    },
+    [notifications, activeTab, getNotificationId]
+  );
+
+  const getActionDescriptionForRow = (notification: FarcasterNotification): string => {
+    const cast = notification.cast;
+    switch (notification.type) {
+      case NotificationType.Reply:
+        return cast ? `@${cast.author.username} replied` : 'Someone replied';
+      case NotificationType.Mention:
+        return cast ? `@${cast.author.username} mentioned you` : 'Someone mentioned you';
+      case NotificationType.Likes:
+        return `${notification.reactions?.length || 1} like${(notification.reactions?.length || 1) > 1 ? 's' : ''}`;
+      case NotificationType.Follows:
+        return `${notification.follows?.length || 1} new follower${(notification.follows?.length || 1) > 1 ? 's' : ''}`;
+      case NotificationType.Recasts:
+        return `${notification.reactions?.length || 1} recast${(notification.reactions?.length || 1) > 1 ? 's' : ''}`;
+      default:
+        return '';
+    }
+  };
+
+  const renderNotificationRow = (notification: FarcasterNotification, idx: number) => {
+    const { cast } = notification;
+    const timeAgoStr = formatDistanceToNowStrict(new Date(notification.most_recent_timestamp || ''));
+    const actionDescription = getActionDescriptionForRow(notification);
+    const notificationId = getNotificationId(notification);
+    const isNotificationRead = isRead(notificationId);
+
+    // Handle follow notifications specially
+    if (notification.type === NotificationType.Follows && notification.follows) {
+      const firstFollower = notification.follows[0]?.user;
+      const remainingCount = notification.follows.length - 1;
+
+      return (
+        <li
+          key={`notification-${notification.most_recent_timestamp}`}
+          className={cn(
+            'flex gap-x-4 px-4 py-3 border-b border-muted/50 transition-colors border-l-2',
+            idx === selectedNotificationIdx
+              ? 'bg-muted border-l-blue-500'
+              : 'cursor-pointer bg-background/80 hover:bg-muted/50 border-l-transparent'
+          )}
+          onClick={() => selectNotification(idx)}
+        >
+          <div className="relative mt-1">
+            <Avatar className="h-8 w-8">
+              <AvatarImage src={firstFollower?.pfp_url} />
+              <AvatarFallback>{firstFollower?.username?.slice(0, 2)}</AvatarFallback>
+            </Avatar>
+            {/* Unread indicator */}
+            {!isNotificationRead && <div className="absolute -top-0.5 -left-0.5 h-2.5 w-2.5 bg-info rounded-full" />}
+            {remainingCount > 0 && (
+              <div className="absolute -bottom-1 -right-1 bg-info text-info-foreground text-xs rounded-full h-4 w-4 flex items-center justify-center">
+                +{Math.min(remainingCount, 9)}
+              </div>
+            )}
+          </div>
+          <div className="flex-auto min-w-0">
+            <div className="flex items-center justify-between gap-x-4">
+              <p className="text-sm font-medium text-foreground truncate">{actionDescription}</p>
+              <p className="flex-none text-xs text-foreground/60">
+                <time dateTime={timeAgoStr}>{timeAgoStr}</time>
+              </p>
+            </div>
+            <p className="mt-1 text-sm text-foreground/70 truncate">
+              {firstFollower?.display_name || firstFollower?.username}
+              {remainingCount > 0 && ` and ${remainingCount} other${remainingCount > 1 ? 's' : ''}`}
+            </p>
+          </div>
+        </li>
+      );
+    }
+
+    // Regular notification handling
+    const author = cast?.author || selectedAccount.user;
+
+    return (
+      <li
+        key={`notification-${notification.most_recent_timestamp}`}
+        className={cn(
+          'flex gap-x-4 px-4 py-3 border-b border-muted/50 transition-colors border-l-2',
+          idx === selectedNotificationIdx
+            ? 'bg-muted border-l-blue-500'
+            : 'cursor-pointer bg-background/80 hover:bg-muted/50 border-l-transparent'
+        )}
+        onClick={() => selectNotification(idx)}
+      >
+        <div className="relative mt-1">
+          <Avatar className="h-8 w-8 flex-none">
+            <AvatarImage src={author?.pfp_url} />
+            <AvatarFallback>{author?.username?.slice(0, 2)}</AvatarFallback>
+          </Avatar>
+          {/* Unread indicator */}
+          {!isNotificationRead && <div className="absolute -top-0.5 -left-0.5 h-2.5 w-2.5 bg-info rounded-full" />}
+        </div>
+        <div className="flex-auto min-w-0">
+          <div className="flex items-center justify-between gap-x-4">
+            <p className="text-sm font-medium text-foreground truncate">{actionDescription}</p>
+            <p className="flex-none text-xs text-foreground/60">
+              <time dateTime={timeAgoStr}>{timeAgoStr}</time>
+            </p>
+          </div>
+          {cast?.text && <p className="mt-1 text-sm text-foreground/70 line-clamp-2 break-words">{cast.text}</p>}
+        </div>
+      </li>
+    );
+  };
+
+  const renderSelectedNotificationDetail = () => {
+    const notification = notifications[selectedNotificationIdx];
+    if (!notification) return null;
+
+    const isReplyOrMention =
+      notification.type === NotificationType.Reply || notification.type === NotificationType.Mention;
+
+    const isFollow = notification.type === NotificationType.Follows;
+
+    // Handle follow notifications
+    if (isFollow && notification.follows) {
+      return (
+        <div className="flex-1 min-w-0 border-l border-muted flex flex-col">
+          <div className="px-4 py-3 border-b border-muted/50 bg-muted/30">
+            <h3 className="text-sm font-medium text-foreground">
+              {notification.follows.length} New Follower{notification.follows.length > 1 ? 's' : ''}
+            </h3>
+          </div>
+          <div className="flex-1 overflow-y-auto p-4">
+            <div className="space-y-3">
+              {notification.follows?.map((follow) => (
+                <CompactFollowerProfile key={follow.user.fid} user={follow.user} viewerFid={viewerFid || ''} />
+              ))}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Handle other notification types that don't have casts
+    if (!notification.cast) return null;
+
+    return (
+      <div className="flex-1 min-w-0 border-l border-muted flex flex-col">
+        {/* Show parent cast for replies and mentions */}
+        {isReplyOrMention && (
+          <div className="border-b border-muted/50">
+            {isLoadingParent ? (
+              <div className="p-4">
+                <SkeletonCastRow />
+              </div>
+            ) : parentCast ? (
+              <>
+                <div className="px-4 py-2 text-sm text-foreground/60 bg-muted/30">Replying to:</div>
+                <CastRow
+                  cast={parentCast}
+                  showChannel
+                  onCastClick={() => router.push(`/conversation/${parentCast.hash}`)}
+                />
+              </>
+            ) : notification.cast.parent_hash ? (
+              <div className="px-4 py-3 text-sm text-foreground/60">Parent cast not found</div>
+            ) : null}
+          </div>
+        )}
+
+        {/* The reply/mention/like/recast cast */}
+        <CastRow
+          cast={notification.cast}
+          showChannel
+          isSelected={true}
+          onCastClick={() => router.push(`/conversation/${notification.cast?.hash}`)}
+        />
+      </div>
+    );
+  };
+
+  if (!viewerFid) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-foreground/60">Please connect an account to view notifications.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-screen bg-background">
+      {/* Header */}
+      <div className="border-b border-muted px-4 py-3">
+        {/* Tabs with Refresh Button */}
+        <Tabs value={activeTab} onValueChange={(value) => changeTab(value as NotificationTab)}>
+          <div className="flex items-center justify-between">
+            <TabsList className="grid grid-cols-5 flex-1 mr-3">
+              <TabsTrigger value={NotificationTab.replies} className="text-xs relative">
+                Replies
+                {activeTab === NotificationTab.replies &&
+                  (() => {
+                    const notificationIds = notificationsByType[NotificationTab.replies].map(getNotificationId);
+                    const unreadCount = getUnreadCount(NotificationTab.replies, notificationIds);
+                    return unreadCount > 0 ? (
+                      <span className="absolute -top-1 -right-1 bg-info text-info-foreground text-xs rounded-full h-4 min-w-[1rem] px-1 flex items-center justify-center">
+                        {unreadCount > 99 ? '99+' : unreadCount}
+                      </span>
+                    ) : null;
+                  })()}
+              </TabsTrigger>
+              <TabsTrigger value={NotificationTab.mentions} className="text-xs relative">
+                Mentions
+                {activeTab === NotificationTab.mentions &&
+                  (() => {
+                    const notificationIds = notificationsByType[NotificationTab.mentions].map(getNotificationId);
+                    const unreadCount = getUnreadCount(NotificationTab.mentions, notificationIds);
+                    return unreadCount > 0 ? (
+                      <span className="absolute -top-1 -right-1 bg-info text-info-foreground text-xs rounded-full h-4 min-w-[1rem] px-1 flex items-center justify-center">
+                        {unreadCount > 99 ? '99+' : unreadCount}
+                      </span>
+                    ) : null;
+                  })()}
+              </TabsTrigger>
+              <TabsTrigger value={NotificationTab.likes} className="text-xs relative">
+                Likes
+                {activeTab === NotificationTab.likes &&
+                  (() => {
+                    const notificationIds = notificationsByType[NotificationTab.likes].map(getNotificationId);
+                    const unreadCount = getUnreadCount(NotificationTab.likes, notificationIds);
+                    return unreadCount > 0 ? (
+                      <span className="absolute -top-1 -right-1 bg-info text-info-foreground text-xs rounded-full h-4 min-w-[1rem] px-1 flex items-center justify-center">
+                        {unreadCount > 99 ? '99+' : unreadCount}
+                      </span>
+                    ) : null;
+                  })()}
+              </TabsTrigger>
+              <TabsTrigger value={NotificationTab.recasts} className="text-xs relative">
+                Recasts
+                {activeTab === NotificationTab.recasts &&
+                  (() => {
+                    const notificationIds = notificationsByType[NotificationTab.recasts].map(getNotificationId);
+                    const unreadCount = getUnreadCount(NotificationTab.recasts, notificationIds);
+                    return unreadCount > 0 ? (
+                      <span className="absolute -top-1 -right-1 bg-info text-info-foreground text-xs rounded-full h-4 min-w-[1rem] px-1 flex items-center justify-center">
+                        {unreadCount > 99 ? '99+' : unreadCount}
+                      </span>
+                    ) : null;
+                  })()}
+              </TabsTrigger>
+              <TabsTrigger value={NotificationTab.follows} className="text-xs relative">
+                Follows
+                {activeTab === NotificationTab.follows &&
+                  (() => {
+                    const notificationIds = notificationsByType[NotificationTab.follows].map(getNotificationId);
+                    const unreadCount = getUnreadCount(NotificationTab.follows, notificationIds);
+                    return unreadCount > 0 ? (
+                      <span className="absolute -top-1 -right-1 bg-info text-info-foreground text-xs rounded-full h-4 min-w-[1rem] px-1 flex items-center justify-center">
+                        {unreadCount > 99 ? '99+' : unreadCount}
+                      </span>
+                    ) : null;
+                  })()}
+              </TabsTrigger>
+            </TabsList>
+            <div className="flex gap-2">
+              <KbdTooltip shortcut="alt+e">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    const notificationIds = notifications.map(getNotificationId);
+                    useNotificationStore.getState().markAllAsRead(activeTab, notificationIds);
+                  }}
+                  disabled={loadingByType[activeTab]}
+                  className="flex-shrink-0"
+                >
+                  Mark all read
+                </Button>
+              </KbdTooltip>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" className="flex-shrink-0 px-2">
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={refreshNotifications} disabled={loadingByType[activeTab]}>
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                    Refresh
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => {
+                      console.log('Manual sync triggered');
+                      useNotificationStore.getState().syncToSupabase();
+                    }}
+                  >
+                    <Cloud className="mr-2 h-4 w-4" />
+                    Sync to cloud
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+        </Tabs>
+      </div>
+
+      {/* Main content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Notifications list */}
+        <div className="w-1/2 min-w-0 flex flex-col">
+          <div className="flex-1 overflow-hidden" ref={listContainerRef}>
+            {isEmpty(notifications) && !loadingByType[activeTab] ? (
+              <div className="flex items-center justify-center h-full">
+                <p className="text-foreground/60">No notifications found.</p>
+              </div>
+            ) : (
+              <SelectableListWithHotkeys
+                data={notifications}
+                selectedIdx={selectedNotificationIdx}
+                setSelectedIdx={(idx) => {
+                  // Don't update selection while loading to prevent jitter
+                  if (!loadingByType[activeTab]) {
+                    selectNotification(idx);
+                  }
+                }}
+                renderRow={renderNotificationRow}
+                onSelect={onSelect}
+                isActive={!isNewCastModalOpen && !loadingByType[activeTab]}
+                pinnedNavigation={true}
+                containerHeight="100%"
+                scopes={[HotkeyScopes.GLOBAL, HotkeyScopes.INBOX]}
+                getItemKey={(item) => getNotificationId(item)}
+                estimatedItemHeight={100}
+              />
+            )}
+          </div>
+
+          <div className="border-t border-muted p-3 bg-background/95">
+            {loadingByType[activeTab] && notifications.length > 0 ? (
+              <div className="flex flex-col items-center justify-center gap-2 py-2">
+                <Loading />
+                <span className="text-sm text-foreground/70">Loading more notifications...</span>
+              </div>
+            ) : (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={loadMoreNotifications}
+                  disabled={!cursorsByType.current[activeTab] || loadingByType[activeTab]}
+                  className="w-full mb-2"
+                >
+                  Load More
+                </Button>
+                <p className="text-xs text-foreground/50 text-center">{notifications.length} notifications shown</p>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Selected notification detail */}
+        {renderSelectedNotificationDetail()}
+      </div>
+    </div>
+  );
+};
+
+export default Inbox;

--- a/src/web/pages/SearchPage.tsx
+++ b/src/web/pages/SearchPage.tsx
@@ -1,0 +1,295 @@
+import isEmpty from 'lodash.isempty';
+import { usePostHog } from 'posthog-js/react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { Key } from 'ts-key-enum';
+import { CastThreadView } from '@/common/components/CastThreadView';
+import { SearchInterface } from '@/common/components/SearchInterface';
+import { SearchResultsView } from '@/common/components/SearchResultsView';
+import { Interval } from '@/common/types/types';
+import { useCastSearchInfinite } from '@/hooks/queries/useCastSearch';
+import { useToast } from '@/hooks/use-toast';
+import { type SearchFilters, SearchMode, SortType } from '@/services/searchService';
+import { useAccountStore } from '@/stores/useAccountStore';
+import { useListStore } from '@/stores/useListStore';
+import { useNavigationStore } from '@/stores/useNavigationStore';
+import { useRouter } from '@/web/lib/navigation';
+
+const APP_FID = process.env.NEXT_PUBLIC_APP_FID!;
+const SEARCH_LIMIT_INITIAL_LOAD = 5;
+const SEARCH_LIMIT_NEXT_LOAD = 10;
+
+const DEFAULT_FILTERS: SearchFilters = {
+  interval: Interval.d7,
+  mode: SearchMode.LITERAL, // Default to literal mode
+  sortType: SortType.DESC_CHRON,
+};
+
+export default function SearchPage() {
+  const posthog = usePostHog();
+
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCastIdx, setSelectedCastIdx] = useState(-1);
+  const [hasSearched, setHasSearched] = useState(false); // Track if search has been performed
+  const [filters, setFilters] = useState<SearchFilters>(DEFAULT_FILTERS);
+  const [showCastThreadView, setShowCastThreadView] = useState(false);
+  const [submittedSearch, setSubmittedSearch] = useState<{
+    term: string;
+    filters: SearchFilters;
+    requestId: number;
+  } | null>(null);
+
+  const router = useRouter();
+  const { toast } = useToast();
+  const { addSearch, addList, setSelectedListId, lists } = useListStore();
+  const lastTrackedSearchIdRef = useRef<number | null>(null);
+  const searchStartedAtRef = useRef(0);
+  const selectedList = useListStore((state) =>
+    state.selectedListId !== undefined ? state.lists.find((list) => list.id === state.selectedListId) : undefined
+  );
+  // Allow search if we have 3+ chars OR if we have valid operators like from: or channel: OR if we have filters set
+  const hasValidOperators = /(?:from:|channel:|parent:|before:|after:)\S+/.test(searchTerm);
+  const hasActiveFilters = Boolean(filters.authorFid || filters.channelId || filters.parentUrl);
+  const canSearch = searchTerm.trim().length >= 3 || hasValidOperators || hasActiveFilters;
+  const { updateSelectedCast, updateSelectedProfileFid } = useNavigationStore();
+
+  const selectedAccount = useAccountStore((state) => state.accounts[state.selectedAccountIdx]);
+  const viewerFid = selectedAccount?.platformAccountId || APP_FID;
+  const searchQuery = useCastSearchInfinite(submittedSearch?.term ?? '', submittedSearch?.filters, viewerFid, {
+    enabled: !!submittedSearch,
+    initialLimit: SEARCH_LIMIT_INITIAL_LOAD,
+    limit: SEARCH_LIMIT_NEXT_LOAD,
+    queryKeyScope: { source: 'search-page' },
+  });
+  const casts = searchQuery.casts;
+  const isLoading = searchQuery.isPending || searchQuery.isFetching;
+  const hasMore = Boolean(searchQuery.hasNextPage);
+  const error = searchQuery.error instanceof Error ? searchQuery.error : null;
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const searchParam = urlParams.get('search');
+    if (searchParam) {
+      setSearchTerm(searchParam);
+      onSearch(searchParam, DEFAULT_FILTERS);
+    }
+
+    const listId = urlParams.get('list');
+    if (listId) {
+      setSelectedListId(listId);
+    }
+
+    // if navigating away, reset the selected cast and profile
+    return () => {
+      updateSelectedCast();
+      updateSelectedProfileFid();
+      setSelectedListId();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (selectedCastIdx === -1) return;
+
+    if (isEmpty(casts)) {
+      updateSelectedCast();
+      updateSelectedProfileFid();
+    } else {
+      updateSelectedCast(casts[selectedCastIdx]);
+      // Clear selectedProfileFid when selecting a cast (sidebar will use cast author)
+      updateSelectedProfileFid();
+    }
+  }, [selectedCastIdx, casts, updateSelectedCast, updateSelectedProfileFid]);
+
+  useEffect(() => {
+    if (selectedList && selectedList.type === 'search') {
+      const { term, filters } = selectedList.contents as {
+        term?: string;
+        filters?: SearchFilters;
+      };
+
+      setFilters(filters || DEFAULT_FILTERS);
+
+      if (term) {
+        setSearchTerm(term);
+        onSearch(term, filters || DEFAULT_FILTERS);
+      }
+    }
+  }, [selectedList]);
+
+  const onChange = async (text: string) => {
+    setSearchTerm(text);
+    // Reset hasSearched if the user clears the search term
+    if (!text.trim()) {
+      setHasSearched(false);
+    }
+  };
+
+  const getFilters = () => filters;
+  const getSerializedSearch = (term: string, activeFilters: SearchFilters) =>
+    JSON.stringify({
+      term,
+      interval: activeFilters.interval,
+      mode: activeFilters.mode,
+      sortType: activeFilters.sortType,
+      authorFid: activeFilters.authorFid,
+      parentUrl: activeFilters.parentUrl,
+      channelId: activeFilters.channelId,
+    });
+
+  const onSearch = useCallback(
+    async (term?: string, filters?: SearchFilters) => {
+      if (!term) {
+        term = searchTerm;
+      }
+
+      if (isEmpty(filters)) {
+        filters = getFilters();
+      }
+
+      const nextFilters = filters || DEFAULT_FILTERS;
+      const nextRequestId = Date.now();
+      const nextSearch = {
+        term,
+        filters: nextFilters,
+        requestId: nextRequestId,
+      };
+      const isSameSearch =
+        submittedSearch &&
+        getSerializedSearch(submittedSearch.term, submittedSearch.filters) === getSerializedSearch(term, nextFilters);
+
+      setShowCastThreadView(false);
+      setSelectedCastIdx(-1);
+      setHasSearched(true); // Mark that a search has been performed
+      searchStartedAtRef.current = Date.now();
+      posthog.capture('user_start_castSearch', {
+        term,
+      });
+
+      setSubmittedSearch(nextSearch);
+
+      if (isSameSearch) {
+        await searchQuery.refetch();
+      }
+    },
+    [searchQuery, searchTerm, filters, posthog, submittedSearch]
+  );
+
+  useEffect(() => {
+    if (!submittedSearch || searchQuery.isFetching || searchQuery.isError) return;
+    if (lastTrackedSearchIdRef.current === submittedSearch.requestId) return;
+    if (searchQuery.dataUpdatedAt < searchStartedAtRef.current) return;
+
+    const endedAt = Date.now();
+    addSearch({
+      term: submittedSearch.term,
+      startedAt: searchStartedAtRef.current,
+      endedAt,
+      resultsCount: searchQuery.totalResults,
+    });
+    posthog.capture('backend_returns_castSearch', {
+      term: submittedSearch.term,
+      resultsCount: searchQuery.totalResults,
+      duration: endedAt - searchStartedAtRef.current,
+    });
+    lastTrackedSearchIdRef.current = submittedSearch.requestId;
+  }, [
+    submittedSearch,
+    searchQuery.isFetching,
+    searchQuery.isError,
+    searchQuery.totalResults,
+    searchQuery.dataUpdatedAt,
+    addSearch,
+    posthog,
+  ]);
+
+  const onContinueSearch = () => {
+    if (!searchQuery.hasNextPage || searchQuery.isFetchingNextPage) return;
+    void searchQuery.fetchNextPage();
+  };
+
+  const onSaveSearch = async () => {
+    const newIdx = lists.reduce((max, list) => Math.max(max, list.idx), 0) + 1;
+
+    const contents = {
+      term: searchTerm,
+      filters: getFilters(),
+      enabled_daily_email: false,
+    };
+
+    const result = await addList({
+      name: searchTerm,
+      type: 'search',
+      contents,
+      idx: newIdx,
+      account_id: selectedAccount?.id || undefined,
+    });
+
+    if (result.success) {
+      posthog.capture('user_save_list', {
+        contents,
+      });
+
+      toast({
+        title: 'Search saved',
+        description: `"${searchTerm}" has been saved to your lists`,
+      });
+
+      router.push('/lists?tab=search');
+    } else {
+      toast({
+        title: 'Error',
+        description: result.error,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  useHotkeys([Key.Enter, 'meta+enter'], () => onSearch(), [onSearch], {
+    enableOnFormTags: true,
+    enabled: Boolean(canSearch) && !isLoading,
+  });
+
+  const onBack = useCallback(() => {
+    setShowCastThreadView(false);
+  }, []);
+
+  return (
+    <div className="min-w-0 flex-1 px-6 py-4">
+      {!showCastThreadView ? (
+        <>
+          <SearchInterface
+            searchTerm={searchTerm}
+            filters={filters}
+            isLoading={isLoading}
+            canSearch={canSearch}
+            onSearchTermChange={onChange}
+            onFiltersChange={setFilters}
+            onSearch={() => onSearch()}
+            onSaveSearch={onSaveSearch}
+            className="mx-auto"
+          />
+          <div className="mt-6 max-w-4xl mx-auto">
+            <SearchResultsView
+              searchTerm={searchTerm}
+              filters={filters}
+              casts={casts}
+              totalResults={searchQuery.totalResults}
+              isLoading={isLoading}
+              hasSearched={hasSearched}
+              hasMore={hasMore}
+              error={error}
+              selectedCastIdx={selectedCastIdx}
+              onCastSelect={(idx) => {
+                setSelectedCastIdx(idx);
+                setShowCastThreadView(true);
+              }}
+              onLoadMore={onContinueSearch}
+            />
+          </div>
+        </>
+      ) : (
+        <CastThreadView cast={casts[selectedCastIdx]} onBack={onBack} />
+      )}
+    </div>
+  );
+}

--- a/src/web/routes/_app.conversation.$.tsx
+++ b/src/web/routes/_app.conversation.$.tsx
@@ -1,0 +1,20 @@
+// Unit #7 (#754 inbox-search-conversation) — /conversation/<hash> (the
+// app/conversation/[...slug]/page.tsx equivalent, whose own layout.tsx also wraps children
+// in <Home>, so mounting under the `_app` shell matches). This is the deep-link target of the
+// unit-#6 mobile cast tap (`router.push('/conversation/<hash>')`) and the legacy ?castHash=
+// redirect that #6 ported intact — it 404'd on the canary until this unit landed.
+//
+// The Next source is a `[...slug]` CATCH-ALL (handles /conversation/<hash> AND
+// /conversation/<user>/<hash>), so it maps to a TanStack `$` SPLAT route — NOT a single
+// `$hash` segment. The param arrives as `_splat` (a single "a/b" string); ConversationPage
+// rebuilds the Next-shaped slug array from it (see C4 there). SSR shape: /conversation* is
+// excluded from Home.pageRequiresHydrate, so it SSRs content (like /profile), gated by the
+// page's own loading state until the client React Query resolves — CastThreadView →
+// Embeds → VideoEmbed therefore never renders during SSR (the #6 worker-bundle stub holds).
+// Reuses CastThreadView + the provider seam (→ the unit-#10 /api/casts/lookup route) VERBATIM.
+import { createFileRoute } from '@tanstack/react-router';
+import ConversationPage from '@/web/pages/ConversationPage';
+
+export const Route = createFileRoute('/_app/conversation/$')({
+  component: ConversationPage,
+});

--- a/src/web/routes/_app.inbox.tsx
+++ b/src/web/routes/_app.inbox.tsx
@@ -1,0 +1,13 @@
+// Unit #7 (#754 inbox-search-conversation) — /inbox mounted as a child of the `_app` shell
+// (unit #5). Thin route: the ported page logic lives in `@/web/pages/InboxPage` (the
+// established `_app.tsx → Home` thin-route pattern). InboxPage reuses CastRow,
+// SelectableListWithHotkeys (react-virtual), the notification/navigation/account/draft
+// stores, and the FarcasterProvider seam (→ the unit-#10 /api/notifications + /api/casts
+// worker routes) VERBATIM via the unit-#2 next/* aliases. INP `inp:open-notification` is
+// already wired in the page.
+import { createFileRoute } from '@tanstack/react-router';
+import InboxPage from '@/web/pages/InboxPage';
+
+export const Route = createFileRoute('/_app/inbox')({
+  component: InboxPage,
+});

--- a/src/web/routes/_app.search.tsx
+++ b/src/web/routes/_app.search.tsx
@@ -1,0 +1,10 @@
+// Unit #7 (#754 inbox-search-conversation) — /search mounted as a child of the `_app` shell
+// (unit #5). Thin route: the ported page logic lives in `@/web/pages/SearchPage`. SearchPage
+// reuses SearchInterface, SearchResultsView, CastThreadView, and the useCastSearchInfinite
+// RQ hook (→ the unit-#10 /api/search worker route) VERBATIM via the unit-#2 next/* aliases.
+import { createFileRoute } from '@tanstack/react-router';
+import SearchPage from '@/web/pages/SearchPage';
+
+export const Route = createFileRoute('/_app/search')({
+  component: SearchPage,
+});


### PR DESCRIPTION
## Unit #7 — inbox + search + conversation (epic #754, Track B)

Second surface-tier unit of the Next.js → TanStack-Start-on-Cloudflare-Workers migration. Mounts three more herocast pages onto the TanStack route tree as children of the #5 `_app` shell, reusing every shared component **verbatim** via the unit-#2 `next/*` aliases and the unit-#10 `/api/*` worker routes. **Closes #6's one dangling deep-link**: `/conversation/<hash>` (the mobile cast-tap + legacy `?castHash=` redirect target).

Spec: `docs/migration/phase-2-inbox-search.md`. Mirrors unit #6 (`phase-2-feeds-profile.md`).

### Routes added (children of `_app`)
| Route | Page (ported) | Source |
|-------|---------------|--------|
| `/inbox` | `src/web/pages/InboxPage.tsx` | `app/(app)/inbox/page.tsx` |
| `/search` | `src/web/pages/SearchPage.tsx` | `app/(app)/search/page.tsx` |
| `/conversation/*` (splat) | `src/web/pages/ConversationPage.tsx` | `app/conversation/[...slug]/page.tsx` |

### Surgical changes only (everything else byte-identical to the Next source)
- **C1** `next/navigation` → `@/web/lib/navigation` (the unit-#2 adapter, imported directly).
- **C3** drop `'use client'` (+ search's vestigial Next `no-img-element` eslint-disable — no `<img>` in the file).
- **C4** (conversation only) the Next `[...slug]` **catch-all** → a TanStack **`$` splat** route. The param arrives as `_splat` (a single `"a/b"` string), so the page rebuilds the Next-shaped slug array: `((params._splat as string | undefined) ?? '').split('/').filter(Boolean)`. Preserves both `/conversation/<hash>` and `/conversation/<user>/<hash>`.

`next/link` stays as `next/link` (resolved by the #2 build alias). No module-scope `createClient()` in any page (the #6 C2 deferral N/A). No new data path, no shared-file edits, no `vite.config.mts` change (CastRow→Embeds→VideoEmbed already stubbed in #6; bundle stayed under budget without a new stub entry).

### Green gate
- `pnpm web:build` 0 → `pnpm web:typecheck` 0 → live `pnpm typecheck` 0 → `pnpm test` **150/150**.
- Routes generated: `/_app/inbox`, `/_app/search`, `/_app/conversation/$`.
- Worker bundle **2336.89 KiB gzip < 3 MB** (+44 KiB over #6; no new `ssr:false` chunk).
- No secret in the three new client chunks (the `_app.feeds` `APP_MNENOMIC=void 0` match is the #6 benign identifier, not a #7 chunk).

### Verification (real workerd + real browser)
- **SSR 200** on `wrangler dev` for `/inbox`, `/search`, `/conversation/0x…` **and** `/conversation/user/0x…` (both splat forms) — no import-time throw. `/inbox`+`/search` SSR the "Loading herocast" hydrate gate; `/conversation` SSRs the page skeleton (content gated to client → CastThreadView/VideoEmbed never render server-side).
- **Browser canary** (real Chromium): `/conversation` fully renders (shell + titlebar "Conversation" + graceful "Cast not found" on a bad hash); `/inbox`+`/search` hydrate → store-init → AuthContext client-redirect to `/login` (logged-out, same as #6 `/feeds`); client-side nav works; console clean except the expected #3 WalletConnect warnings.
- **Tier-1 review**: dynamic multi-agent adversarial review (parity / ssr-bundle / conventions / correctness, each finding verified) — **0 findings**.

### Deferred (documented, shared with #6/#10)
Logged-in inbox tabs + virtual-list recycle, search input→results, real-data thread — need a session + a quota'd `NEYNAR_API_KEY` (dev key is over quota → 402/404 passthrough). Re-run post-`web:deploy`.

**Do not merge** — awaiting review per the migration's per-unit ship protocol.

Status board: #6 🔍→✅ (PR #768), #7 ☐→🔍.
