### PR TITLE
feat(#754 auth-accounts): unit #9 — auth + accounts + onboarding on TanStack

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,3 +9,8 @@ VITE_SUPABASE_ANON_KEY=
 # VITE_POSTHOG_HOST is optional and defaults to PostHog Cloud US.
 VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST=
+
+# Alchemy RPC key for wagmi/wallet transports (unit #9). Public value, inlined by Vite.
+# Without it the wallet modal still opens but on-chain RPC calls fail (…/v2/undefined).
+# The shared rainbowkit config falls back to NEXT_PUBLIC_ALCHEMY_API_KEY for the Next build.
+VITE_ALCHEMY_API_KEY=

--- a/docs/migration/phase-2-auth-accounts.md
+++ b/docs/migration/phase-2-auth-accounts.md
@@ -1,0 +1,134 @@
+# Unit #9 — auth + accounts + onboarding (OAuth write)
+
+> Track B / epic #754. The **critical-path surface-tier unit**: it alone unblocks #11 (auth/onchain/WASM) → #12 → #13 (cutover). Mounts the real **authentication + accounts + onboarding** surface on the TanStack route tree and wires the worker's OWN OAuth `exchangeCodeForSession` **WRITE** end-to-end — the one path phase-1 proved only the READ half of (`phase-1.md §10`). Blocked-by: **#3 ✅** (provider tree — wallet/auth-context), **#5 ✅** (app shell). Template: `phase-1.md`. Reuse contract: `conventions.md`.
+
+## Objective
+
+Replace the unit-#5 `/login` placeholder with the real login surface, and port the accounts + onboarding pages onto the tree — **zero shared-component re-implementation**, reusing every shared component verbatim through the unit-#2 `next/*` vite aliases and the unit-#3 provider tree:
+
+1. `/login` — the real login surface (`app/(auth)/login/page.tsx`): `UserAuthForm` (email/password + Google OAuth + reset), the logged-in redirect, the `signupOnly`/`view=reset`/`redirect` query handling. Outside the `_app` shell (like the current `routes/login.tsx`).
+2. `/accounts` — the accounts management surface (`app/(app)/accounts/page.tsx`, ~497 LOC): connect-with-Warpcast (QR + signer polling), pay-with-ETH (onchain signer), drag-to-reorder accounts, manage/remove, read-only-upgrade card. Child of the `_app` shell.
+3. `/welcome/new`, `/welcome/connect`, `/welcome/success` — the onboarding flow (`app/(auth)/welcome/*`): create-signer (CreateAccountPage), connect/poll (ConnectAccountPage), onboarding checklist (WelcomeSuccessPage). Outside the `_app` shell (the Next `(auth)` group has no app chrome).
+4. `/auth/auth-code-error` — the OAuth-callback failure landing page (`app/auth/auth-code-error/page.tsx`). The 302 callback's error redirect target.
+5. **The OAuth WRITE** — login THROUGH the worker via the EXISTING 302 callback route `src/web/routes/api/auth/callback.ts` (+ `supabase/server.server.ts` write client). No new auth-write path.
+
+**The load-bearing decision (same as #5/#6): the page *logic* is ported into `src/web/pages/`, but every shared component it renders (`UserAuthForm`, `CreateAccountPage`, `QrCode`, `SwitchWalletButton`, `ConfirmOnchainSignerButton`, `AccountManagementModal`, the stores, the wagmi/rainbowkit providers) is consumed VERBATIM.** The only edits vs. the Next source are the same three surgical, SSR-mandated changes #6 codified (C1/C2/C3 below), plus one shared-file edit the migration deferred to this unit (the rainbowkit ALCHEMY key — strategy.md "Deferred").
+
+## Non-goals
+
+- **No new auth-write path.** The 302-redirect callback (`routes/api/auth/callback.ts`) + the `server.server.ts` write client already exist (phase-1). This unit **wires the round-trip**, it does not add or fork an auth-write seam. (`conventions.md` — "Write the Supabase session".)
+- **No editor** (#8). `/welcome/success`'s "Schedule casts" pushes to `/post`; the email-signup flow pushes to `/post` — `/post` 404s on the canary until #8 lands. Ported intact; lights up for free when #8 ships.
+- **No onchain/WASM** (#11). The pay-with-ETH path renders `ConfirmOnchainSignerButton` (wagmi `writeContract` to the Key Gateway). The wallet UI mounts client-only; the actual onchain account-creation flow (`/farcaster-signup`) is a **dangling link in the live Next app too** (no route exists — verified) and is #11's territory. Ported verbatim (the buttons exist, the route 404s exactly as on Next).
+- **No `/settings`, `/lists`, `/channels`** (#12). The accounts read-only upgrade and `/welcome/success` link to them; they 404 on the canary until #12 — faithful to the live sidebar links.
+- **No new wallet wiring.** `WALLET_ROUTES = ['/accounts', '/welcome/connect', '/settings']` already exists in the unit-#3 `Providers.tsx` — `/accounts` and `/welcome/connect` already get `WalletProviders` (dynamic `ssr:false`, client-only). No `Providers.tsx` edit.
+
+## The surgical changes vs. the Next source (everything else is byte-identical)
+
+| # | Next source | Ported `src/web` form | Why |
+|---|-------------|------------------------|-----|
+| C1 | `import { … } from 'next/navigation'` / `'next/link'` | `import { … } from '@/web/lib/navigation'` / `'@/web/components/link'` | New `src/web` code imports the unit-#2 adapters **directly** (per `conventions.md` / unit #6 C1), not via the build-alias indirection. Same runtime behavior. |
+| C2 | module-scope / render-scope `createClient()` | n/a here — **no change needed** | The accounts page reads `Number(process.env.NEXT_PUBLIC_APP_FID!)` at module scope (allowlisted #4; `Number(undefined)`→NaN, no throw). The only `createClient()` is **inside the shared `UserAuthForm`** at render scope — and login SSRs the `!didLoad` spinner, so `UserAuthForm` (and its `createClient()`) **never render during SSR**. No deferral edit required. (Documented so a reviewer doesn't "add" one.) |
+| C3 | `'use client'` directive | removed | Inert under TanStack. Dropped as noise. |
+
+## The one shared-file edit — the rainbowkit ALCHEMY key (strategy.md "Deferred")
+
+`src/common/helpers/rainbowkit.tsx:9` reads `process.env.NEXT_PUBLIC_ALCHEMY_API_KEY` at **module scope** → `undefined` under Vite (Vite does NOT inline `NEXT_PUBLIC_*`), so wagmi transports resolve to `…/v2/undefined` (the modal opens but every RPC fails). Fix host-agnostic, keeping the **Next build green**:
+
+```ts
+const alchemyApiKey =
+  (import.meta as any).env?.VITE_ALCHEMY_API_KEY ?? process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
+```
+
+- **Vite (this build):** inlines `import.meta.env.VITE_ALCHEMY_API_KEY` → real key → working RPC.
+- **Next/webpack (live app):** `import.meta.env` is `undefined` there; `?.` short-circuits → falls back to `process.env.NEXT_PUBLIC_ALCHEMY_API_KEY`, which `next build` inlines. **The `?.` is load-bearing** — a bare `import.meta.env.X` would throw `TypeError: cannot read properties of undefined` at module load in the Next bundle.
+- **`(import.meta as any)`** keeps the live `pnpm typecheck` (root tsconfig has no `vite/client` types, so `import.meta.env` would otherwise be a type error) green.
+- Add `VITE_ALCHEMY_API_KEY` to `.env.local.example` **and** a `define`-allowlist entry in `vite.config.mts` (public value; `VITE_X` preferred / `NEXT_PUBLIC_X` accepted; **never a secret**). Same class as the unit-#3 PostHog `VITE_*` fix.
+
+This is the ONLY permitted shared-file edit (`conventions.md` "Do NOT … touch a shared file you weren't assigned" is waived for exactly this one, per the kickoff).
+
+## Route-tree topology (children added)
+
+```
+__root.tsx                     Providers + GlobalHotkeys + CommandPalette + PerfPanel
+├── _app.tsx                   <Home><Outlet/></Home>                    (unit #5)
+│   ├── _app.shell-probe.tsx   /shell-probe                              (unit #5)
+│   ├── _app.feeds.tsx         /feeds                                    (unit #6)
+│   ├── _app.profile.*.tsx     /profile, /profile/$slug                  (unit #6)
+│   └── _app.accounts.tsx      /accounts            ← this unit (inside the shell)
+├── login.tsx                  /login               ← this unit (REPLACES the #5 placeholder)
+├── welcome.new.tsx            /welcome/new         ← this unit (outside _app)
+├── welcome.connect.tsx        /welcome/connect     ← this unit (outside _app)
+├── welcome.success.tsx        /welcome/success     ← this unit (outside _app)
+├── auth.auth-code-error.tsx   /auth/auth-code-error ← this unit (outside _app)
+└── api/auth/callback.ts       /api/auth/callback   (phase-1; the OAuth WRITE — unchanged)
+```
+
+`/accounts` is in the Next `(app)` group → gets the `Home` shell → `_app.accounts.tsx`. `/login` and `/welcome/*` are in the Next `(auth)` group (a centered layout, no chrome) and `/auth/auth-code-error` is a standalone path (root layout only) → all **outside `_app`**. The `/welcome/*` pages mount under a pathless `_auth` layout route (`src/web/routes/_auth.tsx` = the faithful port of `app/(auth)/layout.tsx`'s `min-h-screen flex items-center justify-center` wrapper). `/login` keeps its standalone `routes/login.tsx` (per the kickoff) and self-centers (`LoginContent` carries its own `min-h-screen`), so it renders identically without the `_auth` wrapper; `/auth/auth-code-error` self-centers too.
+
+## SSR render analysis (which pages render server-side — drives the bundle stub decision)
+
+The provider tree (`Providers.tsx`, unit #3) gates wallet routes behind `WalletProviders` = `dynamic(ssr:false)` → renders `null` during SSR. The `Home` shell gates `pageRequiresHydrate` routes behind the `isHydrated=false` "Loading herocast" gate during SSR. So:
+
+| Route | In `_app`? | Wallet route? | SSR renders the page body? |
+|-------|-----------|---------------|----------------------------|
+| `/login` | no | no | **no** — `LoginContent` returns the `!didLoad` spinner; `UserAuthForm` never mounts server-side |
+| `/accounts` | yes | **yes** | **no** — `Home` renders the hydrate gate (pageRequiresHydrate) AND `WalletProviders` is null on SSR |
+| `/welcome/new` | no | no | **no (by design)** — `CreateAccountPage` → `warpcastLogin` → `@farcaster/hub-web` factory can't run during workerd SSR (G1), so it's mounted `dynamic(ssr:false)`; SSRs the centered `_auth` layout + null, content paints client-side |
+| `/welcome/connect` | no | **yes** | **no** — `WalletProviders` null on SSR gates the whole subtree (and `WelcomeConnectPage` is `ssrClientOnlyModules`-stubbed, G1) |
+| `/welcome/success` | no | no | **yes** — SSRs the onboarding card (accounts `[]` pre-hydrate → connected-account block skipped) |
+| `/auth/auth-code-error` | no | no | **yes** — pure static page |
+
+**Consequence:** the wallet-dependent leaves (`SwitchWalletButton`, `ConfirmOnchainSignerButton` — both statically `import … from '@rainbow-me/rainbowkit'`) are imported ONLY by `/accounts` + `/welcome/connect`, and **neither renders during SSR**. So they are safe to stub in the workerd (`ssr`) env if they push the worker bundle over the 3 MB limit (the stub throws only when rendered, which never happens server-side).
+
+## Files
+
+- **New (this spec):** `docs/migration/phase-2-auth-accounts.md`.
+- **New (page logic, ported):** `src/web/pages/LoginPage.tsx`, `src/web/pages/AccountsPage.tsx`, `src/web/pages/WelcomeConnectPage.tsx`, `src/web/pages/WelcomeSuccessPage.tsx`, `src/web/pages/WelcomeNewPage.tsx` (client-only `dynamic(ssr:false)` wrapper of the shared `CreateAccountPage` — see G1), `src/web/pages/AuthCodeErrorPage.tsx`.
+- **New (thin routes):** `src/web/routes/_app.accounts.tsx`, `src/web/routes/_auth.tsx` (pathless layout = port of `app/(auth)/layout.tsx`), `src/web/routes/_auth.welcome.new.tsx`, `src/web/routes/_auth.welcome.connect.tsx`, `src/web/routes/_auth.welcome.success.tsx`, `src/web/routes/auth.auth-code-error.tsx`. (The `_auth` pathless layout adds no URL segment; `/welcome/*` resolve as expected — verified in `routeTree.gen.ts`. `/login` keeps its standalone `routes/login.tsx` per the kickoff and self-centers.)
+- **Replace wholesale:** `src/web/routes/login.tsx` (the unit-#5 placeholder → the real login route mounting `LoginPage`).
+- **Edit (the one shared file):** `src/common/helpers/rainbowkit.tsx` (the ALCHEMY host-agnostic read — above).
+- **Edit (migration-owned):** `vite.config.mts` (`define` += `NEXT_PUBLIC_ALCHEMY_API_KEY`; **`ssrClientOnlyModules` += `AccountsPage|WelcomeConnectPage`** — the G1 init-crash fix), `.env.local.example` (`VITE_ALCHEMY_API_KEY=`), `docs/migration/strategy.md` (status: #6 → ✅; #9 → 🔍 + PR ref; clear the rainbowkit deferred follow-up). (No `conventions.md` edit — this unit reuses every seam unchanged and introduces none; the auth-write callback row is already accurate. The OAuth WRITE round-trip is wired but only fully provable with real Supabase secrets + a configured provider — see the canary DoD.)
+- **Untouched:** `app/`, `pages/`, `next.config.mjs`, `vercel.json`, `src/globals.css`, and **every shared `src/` file except `rainbowkit.tsx`**.
+
+## Reuse contract (per `conventions.md`)
+
+- **Navigation:** `@/web/lib/navigation` (`useRouter`/`useSearchParams`) + `@/web/components/link` — imported directly in new code (C1).
+- **Shell mount:** `/accounts` is a child of `_app` (unit #5); auth/onboarding pages sit outside `_app` (like `routes/login.tsx`).
+- **Auth READ:** `getUserFn` / the `server.server.ts` read client — unchanged.
+- **Auth WRITE:** the **302-redirect callback** `routes/api/auth/callback.ts` + `server.server.ts` write client — unchanged. **`setCookie` survives only on the non-2xx (302) response** (R2). Do NOT convert to a 200 JSON auth-write.
+- **Supabase (browser):** `getSupabaseClient()`/`createClient()` lazy singleton — reused inside `UserAuthForm`/`AuthContext` verbatim; never called at module scope in ported code.
+- **Wallet:** the unit-#3 route-scoped `WalletProviders`; `config`/`rainbowKitTheme` from `@/common/helpers/rainbowkit` (the ALCHEMY-fixed shared file).
+- **`define` allowlist:** ported pages read only `NEXT_PUBLIC_APP_FID` at module scope (allowlisted #4). The new public key is `NEXT_PUBLIC_ALCHEMY_API_KEY`/`VITE_ALCHEMY_API_KEY` (added here).
+- **Bundle diet:** extend the existing `ssrClientOnlyStubPlugin` regex if needed — do NOT fork a new stub mechanism.
+
+## Gotchas (this unit)
+
+- **G1 (load-bearing) — the `@farcaster/hub-web` module-scope factory crashes worker INIT.** This was the single hardest issue in the unit; the fix is two-pronged.
+  - **Symptom:** with the auth/accounts pages mounted, EVERY route 500s at worker init with `Error: Disallowed operation called within global scope … generating random values` — including `/api/health` and the unrelated probes. The stack bottoms out in `@farcaster/hub-web`'s `Factory.build()` → `@noble/hashes` `randomBytes` (`crypto.getRandomValues`), which hub-web's single-file bundle runs **at module top-level** to define its test factories. workerd forbids random-gen in global scope.
+  - **Why it appeared now (not in #6):** hub-web's factory is pulled by `warpcastLogin` (`NobleEd25519Signer`), `AccountManagement`'s `Change*Form` (`UserDataType`), and `getProvider`. When only a SSR-**gated** route (feeds — hydrate gate) or a lazily-chunked component (`CreateAccountPage`) imports it, the factory lives in a **lazy chunk** that's never loaded during SSR, so it only ever runs in the browser (random-gen is fine there). The auth/accounts routes are the first **eager, ungated** importers, so Rollup HOISTED the factory module into the eager worker-entry (`router`) chunk → it ran at init → universal 500. `moduleSideEffects:false` can NOT drop it (the factory vars are transitively *referenced* by used hub-web exports), so tree-shaking is not the lever.
+  - **Fix part A — stub the two client-only ROUTE PAGES.** `/accounts` (Home hydrate gate) and `/welcome/connect` (WalletProviders null-on-SSR) never render their body during SSR, so `AccountsPage` and `WelcomeConnectPage` are added to `ssrClientOnlyModules` (`vite.config.mts`). This drops their ENTIRE client-only graph (wallet stack + hub-web factory) out of the worker, so the factory is no longer shared into the eager chunk. This **supersedes** stubbing the individual wallet leaves (`SwitchWalletButton`/`ConfirmOnchainSignerButton`) — they're only reachable via these two pages.
+  - **Fix part B — `/welcome/new` mounts `CreateAccountPage` via `dynamic(ssr:false)`** (`src/web/pages/WelcomeNewPage.tsx`). Unlike /accounts and /welcome/connect, /welcome/new is NOT SSR-gated, so it WOULD render `CreateAccountPage` during SSR — loading the factory chunk and throwing (caught → 200 but empty body). The `next/dynamic` shim with `ssr:false` never invokes the loader on the server, so the chunk is never imported during SSR and the factory never runs there; the real component mounts after hydration (account-creation/keygen is inherently client-side anyway).
+  - **Verified:** all routes SSR **200 with zero `Disallowed operation` throws** (`/welcome/new` throw count went 1 → 0), `/feeds`/`/shell-probe` unregressed. Worker bundle **2317.73 KiB gzip** (+24 KiB over unit #6's 2293.75 KiB; the page stubs keep the heavy accounts graph out of the worker). The `define`-pinned ALCHEMY key adds no client leak (public value, like live Next).
+- **G2 — the OAuth WRITE is the de-risk target (phase-1 §10).** The callback returns **302**; TanStack merges `Set-Cookie` onto a handler Response ONLY when non-2xx, so the chunked `sb-<ref>-auth-token.0/.1` cookies survive. The `next` redirect param is hardened (single leading `/`, reject `//`); `X-Forwarded-Host` is dropped (no trusted LB on a bare Worker); `@supabase/ssr`'s own `parseCookieHeader` is used (single decode). **All already implemented in `callback.ts` + `server.server.ts` (phase-1).** This unit's job: prove the round-trip (login through the worker → callback 302 sets cookies → a later request's `getUserFn` returns a real UUID → a logged-in page renders).
+- **G3 — login SSRs the spinner, not the form.** `LoginContent` returns the `!didLoad` loading state on the server; `UserAuthForm` (with its render-scope `createClient()`) only mounts after the client `AuthProvider` effect sets `didLoad`. This is the forkability-safe path (login SSRs 200 with no secrets). Do NOT "fix" it by rendering the form during SSR.
+- **G4 — the AuthContext logged-out redirect bounces non-excluded routes to `/login`.** `/accounts`, `/welcome/*`, and `/auth/auth-code-error` are NOT in the AuthContext exclusion list (`/login`, `/profile`, `/conversation`, `/analytics`), so a logged-out visitor is client-redirected to `/login` after `didLoad`. This is verbatim live-app behavior — preserved, not changed.
+- **G5 — route-tree typecheck is generated.** New routes fail `pnpm web:typecheck` (`'/accounts' not assignable to keyof FileRoutesByPath`) until `vite build` regenerates `routeTree.gen.ts`. **Build once, then typecheck** (same as #6/#10).
+- **G6 — `/farcaster-signup` is a dangling link in the live app.** The accounts page's "Create new account" buttons `router.push('/farcaster-signup')` — no such route exists in `app/` or `pages/` (verified). Ported verbatim; it 404s on the canary exactly as on live Next. Out of scope (the onchain signup surface is #11/#12).
+
+## Definition of Done / cf-canary
+
+- [x] `pnpm web:build` 0, `pnpm web:typecheck` 0 (after a build regenerates `routeTree.gen.ts`), live `pnpm typecheck` 0 (the rainbowkit edit is shared), `pnpm test` all passing.
+- [x] Routes generated: `/accounts`, `/login`, `/welcome/new`, `/welcome/connect`, `/welcome/success`, `/auth/auth-code-error` (verified in `routeTree.gen.ts` — pathless `_auth` resolves to `/welcome/*`).
+- [x] **Worker bundle < 3 MB gzip** (`web:deploy:dry-run`) — **2317.73 KiB gzip** (+24 KiB over unit #6's 2293.75 KiB; the G1 page stubs keep the heavy accounts/wallet graph out of the worker).
+- [x] **No secret VALUE in the client bundle** — `NEYNAR_API_KEY` name absent from `dist/client`; secrets `define`-pinned to `undefined`. `NEXT_PUBLIC_ALCHEMY_API_KEY` is a public key (client-exposed by design, same as on live Next; only inlined when `VITE_ALCHEMY_API_KEY`/`.env.local` is set at build).
+- [x] `/login` and `/accounts` SSR **200 on workerd with NO secrets** (`pnpm web:serve`, `.dev.vars` moved aside) — forkability bar. All six new routes + `/api/health` SSR 200 with zero `Disallowed operation` throws, with and without secrets.
+- [ ] **OAuth WRITE round-trip (needs real secrets + an OAuth provider):** with `SUPABASE_URL`/`SUPABASE_ANON_KEY` in `.dev.vars` (+ `VITE_SUPABASE_*` in `.env.local`) and a configured provider, log in THROUGH the worker — the callback 302 sets the chunked `sb-*` cookies, a subsequent request's `getUserFn` returns a real Supabase UUID, and a logged-in page renders. *(Canary prerequisite: without real Supabase secrets + a provider the shell still SSRs 200 (forkability bar) but the login round-trip cannot complete — note in the canary log.)*
+- [ ] **Wallet modal opens AND a wallet RPC call succeeds** on `/accounts` (the ALCHEMY fix is what makes RPC work, not just the modal opening).
+- [ ] The dev Neynar key may be over monthly quota (HTTP 402): any feed/profile data on logged-in pages returns the quota error (correct passthrough) — render empty/loading gracefully; treat 402 as "needs a quota'd key", not a bug.
+
+## Review + ship
+
+- **Tier-1:** `/code-review` on the diff (+ an adversarial multi-dimension review workflow) until clean. (Tier-2 codex integration review runs at the surface-tier boundary AFTER #6–#9 all land — NOT in this unit.)
+- Update strategy.md (#9 → 🔍 + PR ref; #6 → ✅; clear the rainbowkit deferred item). Open a PR to `main` (`feat(#754 auth-accounts): unit #9 — auth + accounts + onboarding on TanStack`). Do NOT merge.
+</content>
+</invoke>

--- a/docs/migration/strategy.md
+++ b/docs/migration/strategy.md
@@ -35,7 +35,7 @@ Sizes leveled (S/M/L, none >~2× another). Status: ☐ todo · ◐ in-progress �
 | 6 | port: feeds + profile (CastRow + react-virtual) | L | ✅ | 5 | `phase-2-feeds-profile.md` (PR #768) |
 | 7 | port: inbox + search + conversation | M–L | ☐ | 6 | `phase-2-inbox-search.md` |
 | 8 | port: editor (TipTap) + embeds | L | ☐ | 3,5 | `phase-2-editor.md` |
-| 9 | port: auth + accounts + onboarding (OAuth write) | L | 🔍 | 3,5 | `phase-2-auth-accounts.md` |
+| 9 | port: auth + accounts + onboarding (OAuth write) | L | 🔍 | 3,5 | `phase-2-auth-accounts.md` (PR #771) |
 | 10 | port: data API routes behind FarcasterProvider (~19) | L | ✅ | 0,4 | `phase-3-data-routes.md` (PR #767) |
 | 11 | port: auth/onchain/proxy routes + trek-WASM | L | ☐ | 0,9 | `phase-3-auth-onchain-wasm.md` |
 | 12 | port: standalone subtrees + CRUD *(tracking bucket — decompose when foundation lands)* | bucket | ☐ | 5,10,11 | `phase-2-standalone-surfaces.md` |

--- a/docs/migration/strategy.md
+++ b/docs/migration/strategy.md
@@ -32,10 +32,10 @@ Sizes leveled (S/M/L, none >~2× another). Status: ☐ todo · ◐ in-progress �
 | 3 | port: provider tree (wallet/posthog/persist/auth ctx) | L | ✅ | 2 | `phase-2-providers.md` |
 | 4 | port: stores + RQ hooks SSR-safety pass | S–M | ✅ | 3 | `phase-2-stores-hooks.md` |
 | 5 | port: app shell + sidebar + command palette | L | ✅ | 2,3,4 | `phase-2-shell.md` (PR #766) |
-| 6 | port: feeds + profile (CastRow + react-virtual) | L | 🔍 | 5 | `phase-2-feeds-profile.md` (PR #768) |
+| 6 | port: feeds + profile (CastRow + react-virtual) | L | ✅ | 5 | `phase-2-feeds-profile.md` (PR #768) |
 | 7 | port: inbox + search + conversation | M–L | ☐ | 6 | `phase-2-inbox-search.md` |
 | 8 | port: editor (TipTap) + embeds | L | ☐ | 3,5 | `phase-2-editor.md` |
-| 9 | port: auth + accounts + onboarding (OAuth write) | L | ☐ | 3,5 | `phase-2-auth-accounts.md` |
+| 9 | port: auth + accounts + onboarding (OAuth write) | L | 🔍 | 3,5 | `phase-2-auth-accounts.md` |
 | 10 | port: data API routes behind FarcasterProvider (~19) | L | ✅ | 0,4 | `phase-3-data-routes.md` (PR #767) |
 | 11 | port: auth/onchain/proxy routes + trek-WASM | L | ☐ | 0,9 | `phase-3-auth-onchain-wasm.md` |
 | 12 | port: standalone subtrees + CRUD *(tracking bucket — decompose when foundation lands)* | bucket | ☐ | 5,10,11 | `phase-2-standalone-surfaces.md` |
@@ -114,7 +114,7 @@ Run a codex subagent across the whole `src/web` tree (not a single diff) at:
 
 ## Deferred / known follow-ups (surfaced during units; not yet fixed)
 
-- **[#9 auth/accounts] `src/common/helpers/rainbowkit.tsx:9` reads `process.env.NEXT_PUBLIC_ALCHEMY_API_KEY` at module scope → `undefined` under Vite** (not inlined), so wagmi transports resolve to `…/v2/undefined`. The wallet modal still *opens* (so it didn't block #3), but RPC calls fail. Fix when porting wallet functionality: make it host-agnostic (`import.meta.env.VITE_ALCHEMY_API_KEY ?? process.env.NEXT_PUBLIC_ALCHEMY_API_KEY`) — it's a *shared* file so the change must keep the Next build working. Add `VITE_ALCHEMY_API_KEY` to `.env.local.example`. (Same class as the PostHog `VITE_*` fix in #3.)
+- ~~**[#9 auth/accounts] `src/common/helpers/rainbowkit.tsx:9` reads `process.env.NEXT_PUBLIC_ALCHEMY_API_KEY` at module scope → `undefined` under Vite**~~ **RESOLVED in #9.** Made host-agnostic: `(import.meta as any).env?.VITE_ALCHEMY_API_KEY ?? process.env.NEXT_PUBLIC_ALCHEMY_API_KEY` (the `?.` keeps the Next/webpack build — where `import.meta.env` is undefined — from throwing; the `as any` keeps the root-tsconfig typecheck green). Added `VITE_ALCHEMY_API_KEY` to `.env.local.example` + a `define`-allowlist entry in `vite.config.mts`. Wallet RPC works once `VITE_ALCHEMY_API_KEY` is set at build (canary item).
 - **[cutover/#13] Revisit `noImplicitAny`.** #3 set `tsconfig.tanstack.json` `noImplicitAny: false` to match the root Next tsconfig (the reused `src/` carries pre-existing implicit-anys). `strictNullChecks` etc. stay on. Once the shared graph is typed, consider a stricter `src/web/**`-only sub-project to restore `noImplicitAny` for *new* code without forcing it on reused code.
 
 ## Links

--- a/src/common/helpers/rainbowkit.tsx
+++ b/src/common/helpers/rainbowkit.tsx
@@ -6,7 +6,14 @@ import { arbitrum, base, mainnet, optimism, polygon, zora } from '@wagmi/core/ch
 import { createPublicClient } from 'viem';
 import { isDev } from './env';
 
-const alchemyApiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
+// Host-agnostic public key read (#754 unit #9). Vite does NOT inline `NEXT_PUBLIC_*`, so
+// under the TanStack/Vite build this must come from `import.meta.env.VITE_ALCHEMY_API_KEY`
+// (else the transports resolve to `…/v2/undefined` and every RPC fails). The live
+// Next/webpack build has no `import.meta.env` (it is `undefined` there) — the `?.` keeps
+// that from throwing at module load and falls back to `process.env.NEXT_PUBLIC_*`, which
+// `next build` inlines. `import.meta as any` keeps the root-tsconfig `pnpm typecheck` green
+// (it has no `vite/client` types). Public value, never a secret.
+const alchemyApiKey = (import.meta as any).env?.VITE_ALCHEMY_API_KEY ?? process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
 
 const optimismHttp = http(`https://opt-mainnet.g.alchemy.com/v2/${alchemyApiKey}`);
 const mainnetHttp = http(`https://eth-mainnet.g.alchemy.com/v2/${alchemyApiKey}`);

--- a/src/web/pages/AccountsPage.tsx
+++ b/src/web/pages/AccountsPage.tsx
@@ -1,0 +1,507 @@
+// Unit #9 (#754 auth/accounts) — the accounts management surface, ported from
+// app/(app)/accounts/page.tsx. Mounted as a child of the `_app` shell by
+// routes/_app.accounts.tsx (it lives in the Next `(app)` group → gets the app chrome).
+//
+// Surgical changes vs. the Next source (everything else byte-identical):
+//   C1  `next/navigation` → `@/web/lib/navigation` (the unit-#2 adapter, imported directly)
+//   C3  `'use client'` removed (inert under TanStack)
+//
+// SSR-safety: `/accounts` never renders during SSR — `Home` shows the `isHydrated=false`
+// hydrate gate (pageRequiresHydrate) AND `WalletProviders` is null on the server (wallet
+// route). So `useAccount()` (wagmi) and the rainbowkit-importing buttons only run client-side.
+// `Number(process.env.NEXT_PUBLIC_APP_FID!)` at module scope is allowlisted (#4) — NaN, no throw.
+import { filter } from 'lodash';
+import isEmpty from 'lodash.isempty';
+import { Download, RefreshCw, UserPlus } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import SortableList, { SortableItem } from 'react-easy-sort';
+import { useAccount } from 'wagmi';
+import AccountManagementModal from '@/common/components/AccountManagement/AccountManagementModal';
+import AlertDialogDemo from '@/common/components/AlertDialog';
+import ConfirmOnchainSignerButton from '@/common/components/ConfirmOnchainSignerButton';
+import HelpCard from '@/common/components/HelpCard';
+import { QrCode } from '@/common/components/QrCode';
+import SwitchWalletButton from '@/common/components/SwitchWalletButton';
+import { AccountPlatformType, AccountStatusType } from '@/common/constants/accounts';
+import { getTimestamp } from '@/common/helpers/farcaster';
+import { useIsMounted } from '@/common/helpers/hooks';
+import { openWindow } from '@/common/helpers/navigation';
+import {
+  callCreateSignerRequest,
+  generateWarpcastSigner,
+  getWarpcastSignerStatus,
+  WarpcastLoginStatus,
+} from '@/common/helpers/warpcastLogin';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { getProvider } from '@/lib/farcaster/providers';
+import { cn } from '@/lib/utils';
+import {
+  type AccountObjectType,
+  hydrateAccounts,
+  PENDING_ACCOUNT_NAME_PLACEHOLDER,
+  useAccountStore,
+} from '@/stores/useAccountStore';
+import { useRouter } from '@/web/lib/navigation';
+
+const APP_FID = Number(process.env.NEXT_PUBLIC_APP_FID!);
+
+enum SignupStateEnum {
+  initial,
+  connecting,
+  done,
+}
+
+export default function AccountsPage() {
+  const router = useRouter();
+  const [signupState, setSignupState] = useState<SignupStateEnum>(SignupStateEnum.initial);
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const { isConnected } = useAccount();
+  const isMounted = useIsMounted();
+  const [selectedAccount, setSelectedAccount] = useState<AccountObjectType>();
+
+  const { accounts, addAccount, setAccountActive, removeAccount, updateAccountUsername, updateAccountDisplayOrder } =
+    useAccountStore();
+
+  const pendingAccounts =
+    accounts.filter(
+      (account) => account.status === AccountStatusType.pending && account.platform === AccountPlatformType.farcaster
+    ) || [];
+  const hasOnlyLocalAccounts =
+    accounts.length && accounts.every((account) => account.platform === AccountPlatformType.farcaster_local_readonly);
+  const hasPendingNewAccounts = pendingAccounts.length > 0;
+  const pendingAccount = hasPendingNewAccounts ? pendingAccounts[0] : null;
+
+  useEffect(() => {
+    if (pendingAccounts?.length && signupState === SignupStateEnum.connecting) {
+      pendingAccounts.forEach((account) => pollForSigner(account.id));
+    }
+  }, [signupState, pendingAccounts, isMounted()]);
+
+  useEffect(() => {
+    if (hasPendingNewAccounts && signupState === SignupStateEnum.initial) {
+      setSignupState(SignupStateEnum.connecting);
+    } else if (!hasPendingNewAccounts && signupState === SignupStateEnum.connecting) {
+      setSignupState(SignupStateEnum.initial);
+    }
+  }, [signupState, hasPendingNewAccounts]);
+
+  const onClickManageAccount = (account: AccountObjectType) => {
+    setSelectedAccount(account);
+    setModalOpen(true);
+  };
+
+  const refreshAccountNames = async () => {
+    setIsLoading(true);
+    await Promise.all(accounts.map(async (account) => await updateAccountUsername(account.id)))
+      .then(async () => {
+        console.log('All account names refreshed successfully');
+        await hydrateAccounts();
+      })
+      .catch((error) => console.error('Error refreshing account names:', error));
+    setIsLoading(false);
+  };
+
+  const onSortEnd = (oldIndex: number, newIndex: number) => {
+    if (oldIndex !== newIndex) {
+      updateAccountDisplayOrder({ oldIndex, newIndex });
+    }
+  };
+
+  const onCreateNewAccount = async () => {
+    const { publicKey, privateKey, signature, requestFid, deadline } = await generateWarpcastSigner();
+    const { token, deeplinkUrl } = await callCreateSignerRequest({
+      publicKey,
+      requestFid,
+      signature,
+      deadline,
+    });
+
+    try {
+      setIsLoading(true);
+      await addAccount({
+        account: {
+          platformAccountId: undefined,
+          status: AccountStatusType.pending,
+          platform: AccountPlatformType.farcaster,
+          publicKey,
+          privateKey,
+          data: { signerToken: token, deeplinkUrl, deadline },
+        },
+      });
+      setIsLoading(false);
+      setSignupState(SignupStateEnum.connecting);
+    } catch (e) {
+      console.log('error when trying to add account', e);
+      setIsLoading(false);
+      setSignupState(SignupStateEnum.initial);
+    }
+  };
+
+  const checkStatusAndActiveAccount = async (pendingAccount: AccountObjectType) => {
+    if (!pendingAccount?.data?.signerToken) return;
+
+    const deadline = pendingAccount.data?.deadline;
+    if (deadline && getTimestamp() > deadline) {
+      await removeAccount(pendingAccount.id);
+      return;
+    }
+
+    const { status, data } = await getWarpcastSignerStatus(pendingAccount.data.signerToken);
+    if (status === WarpcastLoginStatus.success) {
+      const fid = data.userFid;
+      const users = await getProvider().getBulkUsers({ fids: [fid], viewerFid: APP_FID });
+      const user = users[0];
+      await setAccountActive(pendingAccount.id, user.username, {
+        platform_account_id: user.fid.toString(),
+        data,
+      });
+      await hydrateAccounts();
+      window.location.reload();
+    }
+  };
+
+  const pollForSigner = async (accountId: string) => {
+    let tries = 0;
+    while (tries < 60) {
+      tries += 1;
+      await new Promise((r) => setTimeout(r, 2000));
+
+      const account = useAccountStore.getState().accounts.find((account) => account.id === accountId);
+      if (!account) return;
+
+      await checkStatusAndActiveAccount(account);
+
+      if (!isMounted()) return;
+    }
+  };
+
+  const renderSignupForNonLocalAccount = () => (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-2xl flex">
+          You are using a readonly account <Download className="ml-2 mt-1 w-6 h-6" />
+        </CardTitle>
+        <CardDescription>
+          A readonly account is great for browsing, but you need a full account to start casting and interact with
+          others on Farcaster.
+        </CardDescription>
+      </CardHeader>
+      <CardFooter>
+        <Button
+          className="w-full"
+          variant="default"
+          onClick={() => openWindow(`${process.env.NEXT_PUBLIC_URL}/login?signupOnly=true`)}
+        >
+          Switch to a full account
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+
+  const renderCreateSignerStep = () => (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-2xl">Connect your Farcaster account</CardTitle>
+        <CardDescription>Connect with herocast to see and publish casts</CardDescription>
+      </CardHeader>
+      <CardFooter>
+        <Button className="w-full" variant="default" onClick={() => onCreateNewAccount()}>
+          <UserPlus className="mr-1.5 h-5 w-5" aria-hidden="true" />
+          {isLoading ? 'Connecting...' : 'Connect Account'}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+
+  const renderConnectAccountStep = () => {
+    if (isEmpty(pendingAccounts)) return null;
+
+    return (
+      <Card className="bg-background text-foreground">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-2xl">Sign in with Farcaster</CardTitle>
+          <CardDescription className="text-muted-foreground">
+            Pay with Warps in Farcaster app to connect with herocast
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <QrCode
+              deepLink={`https://client.warpcast.com/deeplinks/signed-key-request?token=${pendingAccount?.data?.signerToken}`}
+            />
+          </div>
+
+          <details className="group">
+            <summary className="cursor-pointer flex items-center justify-center text-sm text-muted-foreground hover:text-foreground">
+              <span className="flex items-center gap-2">
+                <span>Pay with ETH instead</span>
+                <svg
+                  className="w-4 h-4 transition-transform group-open:rotate-180"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </span>
+            </summary>
+            <div className="mt-4 pt-4 border-t">
+              <p className="text-sm text-muted-foreground mb-3">Pay with ETH on Optimism to connect</p>
+              {isConnected ? <ConfirmOnchainSignerButton account={pendingAccount!} /> : <SwitchWalletButton />}
+            </div>
+          </details>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  const renderCreateNewOnchainAccountCard = () => (
+    <Card>
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-2xl">Create a new Farcaster account onchain</CardTitle>
+        <CardDescription>
+          No need to connect with Farcaster app. Sign up directly with the Farcaster protocol onchain.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Button variant="default" onClick={() => router.push('/farcaster-signup')}>
+            Create new account
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  const renderActiveAccountsOverview = () => {
+    const activeAccounts = filter(accounts, (account) => account.status === 'active');
+
+    if (isEmpty(activeAccounts)) return null;
+
+    return (
+      <>
+        <div className="flex justify-between pb-2 border-b border-border">
+          <h1 className="text-xl font-semibold leading-7 text-foreground/80">Connected Farcaster accounts</h1>
+        </div>
+        <ul role="list" className="mb-8 divide-y">
+          {activeAccounts.map((item: AccountObjectType) => (
+            <li key={item.id} className="px-2 py-2">
+              <div className="flex items-center gap-x-3">
+                <h3 className="text-foreground/80 flex-auto truncate text-sm font-semibold leading-6">
+                  {item.name || PENDING_ACCOUNT_NAME_PLACEHOLDER}
+                </h3>
+                <p className="truncate text-sm text-foreground/80">{item.status}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </>
+    );
+  };
+
+  const renderUnifiedAccountsPage = () => {
+    const activeAccounts = filter(accounts, (account) => account.status === 'active');
+    const hasMultipleAccounts = accounts.length > 1;
+
+    return (
+      <div className="space-y-6">
+        {/* Header with actions */}
+        <div className="flex justify-between items-center">
+          <Button
+            onClick={() => onCreateNewAccount()}
+            disabled={isLoading || signupState === SignupStateEnum.connecting}
+          >
+            <UserPlus className="mr-2 h-4 w-4" />
+            Connect New Account
+          </Button>
+          {accounts.length > 0 && (
+            <Button variant="outline" size="sm" disabled={isLoading} onClick={() => refreshAccountNames()}>
+              <RefreshCw className={cn(isLoading && 'animate-spin', 'mr-2 h-4 w-4')} />
+              Refresh
+            </Button>
+          )}
+        </div>
+
+        {/* Main content area */}
+        <div className="space-y-6">
+          <div className="grid gap-6 lg:grid-cols-2">
+            {/* Left column: Existing accounts or empty state */}
+            <div className="space-y-4">
+              {accounts.length === 0 ? (
+                <Card className="border-dashed">
+                  <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+                    <UserPlus className="h-12 w-12 text-muted-foreground mb-4" />
+                    <h3 className="text-lg font-semibold mb-2">No accounts connected</h3>
+                    <p className="text-sm text-muted-foreground">Connect your first Farcaster account to get started</p>
+                  </CardContent>
+                </Card>
+              ) : (
+                <>
+                  <h2 className="text-lg font-semibold flex items-center gap-2">
+                    Your Accounts
+                    <Badge variant="secondary">{accounts.length}</Badge>
+                  </h2>
+                  <SortableList onSortEnd={onSortEnd} className="space-y-2" draggedItemClassName="opacity-50">
+                    {accounts.map((item: AccountObjectType, idx: number) => (
+                      <SortableItem key={item.id}>
+                        <div className="rounded-lg border bg-card p-4 cursor-move hover:bg-accent/50 transition-colors">
+                          <div className="flex items-center justify-between">
+                            <div className="flex items-center gap-3 flex-1 min-w-0">
+                              {/* Drag handle */}
+                              {hasMultipleAccounts && (
+                                <div className="text-muted-foreground">
+                                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                                    <circle cx="4" cy="4" r="1.5" />
+                                    <circle cx="12" cy="4" r="1.5" />
+                                    <circle cx="4" cy="8" r="1.5" />
+                                    <circle cx="12" cy="8" r="1.5" />
+                                    <circle cx="4" cy="12" r="1.5" />
+                                    <circle cx="12" cy="12" r="1.5" />
+                                  </svg>
+                                </div>
+                              )}
+
+                              {/* Account info */}
+                              <div className="flex-1 min-w-0">
+                                <h3 className="font-semibold truncate">
+                                  {item.name || PENDING_ACCOUNT_NAME_PLACEHOLDER}
+                                </h3>
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                  <span>FID: {item.platformAccountId || 'Pending'}</span>
+                                  {idx < 9 && (
+                                    <>
+                                      <span>•</span>
+                                      <span className="font-mono text-xs">Ctrl+{idx + 1}</span>
+                                    </>
+                                  )}
+                                  {item.status !== 'active' && <span className="text-warning">• {item.status}</span>}
+                                </div>
+                              </div>
+                            </div>
+
+                            {/* Actions */}
+                            <div className="flex items-center gap-2 ml-4">
+                              {item.status === 'active' && (
+                                <Button variant="ghost" size="sm" onClick={() => onClickManageAccount(item)}>
+                                  Manage
+                                </Button>
+                              )}
+                              <AlertDialogDemo buttonText="Remove" onClick={() => removeAccount(item.id)} />
+                            </div>
+                          </div>
+                        </div>
+                      </SortableItem>
+                    ))}
+                  </SortableList>
+                </>
+              )}
+            </div>
+
+            {/* Right column: Connect account options */}
+            <div className="space-y-4">
+              {/* Show connection flow or options based on state */}
+              {signupState === SignupStateEnum.initial ? (
+                <>
+                  <h2 className="text-lg font-semibold">Connect Account</h2>
+
+                  {/* Connect with Warpcast - Primary CTA */}
+                  <Card className={accounts.length === 0 ? 'border-primary' : ''}>
+                    <CardHeader>
+                      <CardTitle className="text-lg">Connect with Farcaster</CardTitle>
+                      <CardDescription>Connect your existing Farcaster account via Warpcast</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <Button
+                        className="w-full"
+                        variant={accounts.length === 0 ? 'default' : 'outline'}
+                        onClick={() => onCreateNewAccount()}
+                        disabled={isLoading}
+                      >
+                        <UserPlus className="mr-2 h-4 w-4" />
+                        {isLoading ? 'Connecting...' : 'Connect Account'}
+                      </Button>
+                    </CardContent>
+                  </Card>
+
+                  {/* Create new account option */}
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="text-lg">New to Farcaster?</CardTitle>
+                      <CardDescription>Create a brand new Farcaster account directly onchain</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <Button variant="outline" className="w-full" onClick={() => router.push('/farcaster-signup')}>
+                        Create New Account
+                      </Button>
+                    </CardContent>
+                  </Card>
+                </>
+              ) : (
+                /* Connecting state */
+                <>
+                  <h2 className="text-lg font-semibold">Complete Connection</h2>
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="text-lg">Scan QR Code</CardTitle>
+                      <CardDescription>Scan with Warpcast or pay with ETH to connect</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                      <div>
+                        <QrCode
+                          deepLink={`https://client.warpcast.com/deeplinks/signed-key-request?token=${pendingAccount?.data?.signerToken}`}
+                        />
+                      </div>
+
+                      <details className="group">
+                        <summary className="cursor-pointer flex items-center justify-center text-sm text-muted-foreground hover:text-foreground">
+                          <span className="flex items-center gap-2">
+                            <span>Pay with ETH instead</span>
+                            <svg
+                              className="w-4 h-4 transition-transform group-open:rotate-180"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                            </svg>
+                          </span>
+                        </summary>
+                        <div className="mt-4 pt-4 border-t">
+                          <p className="text-sm text-muted-foreground mb-3">Pay with ETH on Optimism to connect</p>
+                          {isConnected && pendingAccount ? (
+                            <ConfirmOnchainSignerButton account={pendingAccount} />
+                          ) : (
+                            <SwitchWalletButton />
+                          )}
+                        </div>
+                      </details>
+                    </CardContent>
+                  </Card>
+                </>
+              )}
+
+              {/* Help section */}
+              <HelpCard />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-muted/40">
+      <main className="flex-1 overflow-y-auto p-4 sm:px-6 sm:py-6 pb-12">
+        {hasOnlyLocalAccounts ? (
+          <div className="flex">{renderSignupForNonLocalAccount()}</div>
+        ) : (
+          renderUnifiedAccountsPage()
+        )}
+      </main>
+      <AccountManagementModal account={selectedAccount} open={isModalOpen} setOpen={setModalOpen} />
+    </div>
+  );
+}

--- a/src/web/pages/AuthCodeErrorPage.tsx
+++ b/src/web/pages/AuthCodeErrorPage.tsx
@@ -1,0 +1,51 @@
+// Unit #9 (#754 auth/accounts) — the OAuth-callback failure landing page, ported from
+// app/auth/auth-code-error/page.tsx. The 302 callback (routes/api/auth/callback.ts)
+// redirects here on a failed `exchangeCodeForSession`. Standalone path in the Next tree
+// (NOT in the `(auth)` group), so it sits OUTSIDE the `_app` shell and centers itself.
+//
+// Surgical changes vs. the Next source (everything else byte-identical):
+//   C1  `next/link` → `@/web/components/link`
+//   C3  `'use client'` removed
+import { AlertCircle, LogIn, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import Link from '@/web/components/link';
+
+export default function AuthCodeErrorPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-6">
+      <div className="max-w-md w-full space-y-6 text-center">
+        <div className="flex justify-center">
+          <AlertCircle className="h-16 w-16 text-destructive" />
+        </div>
+
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold text-foreground">Link Expired or Invalid</h1>
+          <p className="text-foreground/70">
+            This password reset link may have expired or already been used. Password reset links are only valid for a
+            limited time.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <Button asChild className="flex items-center justify-center gap-2">
+            <Link href="/login">
+              <RefreshCw className="h-4 w-4" />
+              Request a new reset link
+            </Link>
+          </Button>
+
+          <Button variant="outline" asChild className="flex items-center justify-center gap-2">
+            <Link href="/login">
+              <LogIn className="h-4 w-4" />
+              Back to login
+            </Link>
+          </Button>
+        </div>
+
+        <div className="pt-4 border-t border-border">
+          <p className="text-xs text-foreground/50">If you continue to have problems, please contact support.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/pages/LoginPage.tsx
+++ b/src/web/pages/LoginPage.tsx
@@ -1,0 +1,108 @@
+// Unit #9 (#754 auth/accounts) — the real login surface, ported from
+// app/(auth)/login/page.tsx. Mounted OUTSIDE the `_app` shell by routes/login.tsx
+// (the auth tier has no app chrome, like the Next `(auth)` group).
+//
+// Surgical changes vs. the Next source (everything else byte-identical):
+//   C1  `next/navigation` → `@/web/lib/navigation` (the unit-#2 adapter, imported directly)
+//   C3  `'use client'` removed (inert under TanStack)
+//
+// SSR-safety (G3): `LoginContent` returns the `!didLoad` spinner on the server, so the
+// shared `UserAuthForm` — which calls `createClient()` at render scope — NEVER mounts
+// during SSR. The form paints client-side after AuthProvider's effect resolves the session.
+import { Suspense, useEffect } from 'react';
+import { UserAuthForm } from '@/common/components/UserAuthForm';
+import { useAuth } from '@/common/context/AuthContext';
+import { Card, CardContent } from '@/components/ui/card';
+import { Spinner } from '@/components/ui/spinner';
+import { useRouter, useSearchParams } from '@/web/lib/navigation';
+
+function getSafeRedirect(path: string | null): string | null {
+  if (!path) return null;
+  if (!path.startsWith('/') || path.startsWith('//')) return null;
+  if (path.startsWith('/login')) return null;
+  return path;
+}
+
+function LoginContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { user, didLoad } = useAuth();
+  const signupOnly = searchParams.get('signupOnly');
+  const view = searchParams.get('view');
+  const redirectParam = searchParams.get('redirect');
+  const safeRedirect = getSafeRedirect(redirectParam);
+  const showOnlySignup = signupOnly === 'true' || view === 'reset';
+
+  // Redirect logged-in users
+  useEffect(() => {
+    if (didLoad && user && view !== 'reset') {
+      router.replace(safeRedirect || '/feeds');
+    }
+  }, [didLoad, user, view, router, safeRedirect]);
+
+  // Show minimal loading while checking auth
+  if (!didLoad) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-3">
+          <Spinner size="lg" />
+          <span className="text-sm text-muted-foreground">Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  // Show redirect message if logged in
+  if (user && view !== 'reset') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="flex flex-col items-center gap-3">
+          <Spinner size="lg" />
+          <span className="text-sm text-muted-foreground">Redirecting...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6 bg-background">
+      {/* Logo outside card */}
+      <div className="flex items-center gap-2 mb-8">
+        <img src="/images/logo.png" alt="herocast" width={32} height={32} className="rounded-lg" />
+        <span className="text-xl font-semibold tracking-tight">herocast</span>
+      </div>
+
+      <Card className="w-full max-w-md">
+        <CardContent className="pt-6">
+          <UserAuthForm signupOnly={showOnlySignup} />
+        </CardContent>
+      </Card>
+
+      {/* Footer outside card */}
+      <p className="mt-6 text-center text-xs text-muted-foreground max-w-md">
+        By clicking continue, you agree to our{' '}
+        <a href="https://herocast.xyz/terms" className="underline underline-offset-4 hover:text-foreground">
+          Terms of Service
+        </a>{' '}
+        and{' '}
+        <a href="https://herocast.xyz/privacy" className="underline underline-offset-4 hover:text-foreground">
+          Privacy Policy
+        </a>
+      </p>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-background">
+          <Spinner size="lg" />
+        </div>
+      }
+    >
+      <LoginContent />
+    </Suspense>
+  );
+}

--- a/src/web/pages/WelcomeConnectPage.tsx
+++ b/src/web/pages/WelcomeConnectPage.tsx
@@ -1,0 +1,140 @@
+// Unit #9 (#754 auth/accounts) — the connect-account onboarding step, ported from
+// app/(auth)/welcome/connect/page.tsx. Mounted OUTSIDE the `_app` shell by
+// routes/welcome.connect.tsx (the Next `(auth)` group has no app chrome).
+//
+// Surgical changes vs. the Next source (everything else byte-identical):
+//   C1  `next/navigation` → `@/web/lib/navigation`
+//   C3  `'use client'` removed
+//
+// SSR-safety: `/welcome/connect` is a wallet route (unit-#3 WALLET_ROUTES), so
+// `WalletProviders` is null on the server → this page never renders during SSR; `useAccount()`
+// (wagmi) runs client-only. `Number(process.env.NEXT_PUBLIC_APP_FID!)` is allowlisted (#4).
+import { useEffect, useState } from 'react';
+import { useAccount } from 'wagmi';
+import ConfirmOnchainSignerButton from '@/common/components/ConfirmOnchainSignerButton';
+import { QrCode } from '@/common/components/QrCode';
+import SwitchWalletButton from '@/common/components/SwitchWalletButton';
+import { AccountPlatformType, AccountStatusType } from '@/common/constants/accounts';
+import { getTimestamp } from '@/common/helpers/farcaster';
+import { useIsMounted } from '@/common/helpers/hooks';
+import { getWarpcastSignerStatus, WarpcastLoginStatus } from '@/common/helpers/warpcastLogin';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { getProvider } from '@/lib/farcaster/providers';
+import { type AccountObjectType, hydrateAccounts, useAccountStore } from '@/stores/useAccountStore';
+import { useRouter } from '@/web/lib/navigation';
+
+const APP_FID = Number(process.env.NEXT_PUBLIC_APP_FID!);
+
+const ConnectAccountPage = () => {
+  const router = useRouter();
+  const { isConnected } = useAccount();
+  const { accounts, removeAccount, setAccountActive } = useAccountStore();
+  const [isHydrated, setIsHydrated] = useState(false);
+  const isMounted = useIsMounted();
+
+  useEffect(() => {
+    hydrateAccounts();
+    setIsHydrated(true);
+  }, []);
+
+  const pendingAccounts = accounts.filter(
+    (account) => account.status === AccountStatusType.pending && account.platform === AccountPlatformType.farcaster
+  );
+  const pendingAccount = pendingAccounts?.[0];
+
+  const checkStatusAndActiveAccount = async (pendingAccount: AccountObjectType) => {
+    if (!pendingAccount?.data?.signerToken) return;
+
+    const deadline = pendingAccount.data?.deadline;
+    if (deadline && getTimestamp() > deadline) {
+      await removeAccount(pendingAccount.id);
+      return;
+    }
+
+    const { status, data } = await getWarpcastSignerStatus(pendingAccount.data.signerToken);
+    if (status === WarpcastLoginStatus.success) {
+      const fid = data.userFid;
+      const users = await getProvider().getBulkUsers({ fids: [fid], viewerFid: APP_FID });
+      const user = users[0];
+      await setAccountActive(pendingAccount.id, user.username, {
+        platform_account_id: user.fid.toString(),
+        data,
+      });
+      await hydrateAccounts();
+      router.push('/welcome/success');
+    }
+  };
+
+  const pollForSigner = async (accountId: string) => {
+    let tries = 0;
+    while (tries < 60) {
+      tries += 1;
+      await new Promise((r) => setTimeout(r, 2000));
+
+      const account = useAccountStore.getState().accounts.find((account) => account.id === accountId);
+      if (!account) return;
+      if (!isMounted()) return;
+
+      await checkStatusAndActiveAccount(account);
+    }
+  };
+
+  useEffect(() => {
+    if (pendingAccount) {
+      pendingAccounts.forEach((account) => pollForSigner(account.id));
+    }
+  }, [pendingAccount]);
+
+  if (!isHydrated) {
+    return null;
+  }
+
+  if (pendingAccounts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mx-auto flex flex-col justify-center items-center">
+      <div className="space-y-6 p-10 pb-16 block text-center">
+        <h2 className="text-4xl font-bold tracking-tight">Welcome to herocast</h2>
+        <p className="text-lg text-muted-foreground">Build, engage and grow on Farcaster. Faster.</p>
+        <div className="lg:max-w-lg mx-auto">
+          <div className="grid grid-cols-1 gap-4">
+            <Card className="bg-background text-foreground">
+              <CardHeader className="space-y-1">
+                <CardTitle className="text-2xl">Sign in with Warpcast</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-col items-center justify-center">
+                <QrCode
+                  deepLink={`https://client.warpcast.com/deeplinks/signed-key-request?token=${pendingAccount?.data?.signerToken}`}
+                />
+              </CardContent>
+            </Card>
+            <div className="relative mx-4">
+              <div className="absolute inset-0 flex items-center" aria-hidden="true">
+                <div className="w-full border-t border-border" />
+              </div>
+              <div className="relative flex justify-center">
+                <span className="bg-background px-2 text-sm text-foreground/80">OR</span>
+              </div>
+            </div>
+
+            <Card className="bg-background text-foreground flex flex-col justify-center items-center">
+              <CardHeader className="space-y-1">
+                <CardTitle className="text-2xl">Sign in with Web3 wallet</CardTitle>
+                <CardDescription className="text-muted-foreground">
+                  Pay with ETH on Optimism to connect with herocast
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {isConnected ? <ConfirmOnchainSignerButton account={pendingAccount} /> : <SwitchWalletButton />}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConnectAccountPage;

--- a/src/web/pages/WelcomeNewPage.tsx
+++ b/src/web/pages/WelcomeNewPage.tsx
@@ -1,0 +1,25 @@
+// Unit #9 (#754 auth/accounts) — /welcome/new (the create-signer onboarding entry).
+// In the Next tree app/(auth)/welcome/new/page.tsx re-exports CreateAccountPage; here it
+// must mount CLIENT-ONLY.
+//
+// Why ssr:false: CreateAccountPage → warpcastLogin → @farcaster/hub-web, whose single-file
+// bundle runs `Factory.build()` → `randomBytes` (@noble/hashes crypto.getRandomValues) AT
+// MODULE SCOPE. workerd forbids random-gen in global scope, so importing that chunk during
+// SSR throws ("Disallowed operation called within global scope") and the page renders empty.
+// The account-creation flow (generateWarpcastSigner keygen) is inherently client-side
+// anyway, so we load CreateAccountPage through the next/dynamic shim (ssr:false): the chunk
+// is never imported on the server (the lazy loader isn't invoked during SSR), so the factory
+// never runs there; the real component mounts after hydration. (The wallet route pages —
+// /accounts, /welcome/connect — instead drop their whole graph out of the worker via the
+// `ssrClientOnlyModules` stub because they're already SSR-gated; /welcome/new is NOT gated,
+// so it uses the ssr:false dynamic boundary to avoid rendering anything that pulls hub-web.)
+import dynamic from '@/web/lib/dynamic';
+
+const CreateAccountPage = dynamic(
+  () => import('@/common/components/CreateAccountPage').then((m) => ({ default: m.CreateAccountPage })),
+  { ssr: false, loading: () => null }
+);
+
+export default function WelcomeNewPage() {
+  return <CreateAccountPage />;
+}

--- a/src/web/pages/WelcomeSuccessPage.tsx
+++ b/src/web/pages/WelcomeSuccessPage.tsx
@@ -1,0 +1,233 @@
+// Unit #9 (#754 auth/accounts) — the post-connect onboarding checklist, ported from
+// app/(auth)/welcome/success/page.tsx. Mounted OUTSIDE the `_app` shell by
+// routes/welcome.success.tsx (the Next `(auth)` group has no app chrome).
+//
+// Surgical changes vs. the Next source (everything else byte-identical):
+//   C1  `next/navigation` → `@/web/lib/navigation`; `next/link` → `@/web/components/link`
+//   C3  `'use client'` removed
+//
+// SSR-safety: store reads are selector-based (SSR-safe, #4); the localStorage effect is
+// client-only. Pre-hydration `accounts` is empty → the connected-account block is skipped.
+import { CheckCircle2, LayoutDashboard, Search, SquarePen, User } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { DraftStatus } from '@/common/constants/farcaster';
+import { LOCAL_STORAGE_ONBOARDING_COMPLETED_KEY } from '@/common/constants/localStorage';
+import { JoinedHerocastPostDraft } from '@/common/constants/postDrafts';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Progress } from '@/components/ui/progress';
+import { useAccountStore } from '@/stores/useAccountStore';
+import { useDraftStore } from '@/stores/useDraftStore';
+import { useListStore } from '@/stores/useListStore';
+import Link from '@/web/components/link';
+import { useRouter } from '@/web/lib/navigation';
+
+enum OnboardingStep {
+  login_to_herocast = 'login_to_herocast',
+  connect_farcaster_account = 'connect_farcaster_account',
+  create_keyword_alert = 'create_keyword_alert',
+  pin_channels = 'pin_channels',
+  schedule_cast = 'schedule_cast',
+  done = 'done',
+}
+
+interface OnboardingTaskStatus {
+  [key: string]: boolean;
+}
+
+const onboardingSteps = [
+  {
+    key: OnboardingStep.login_to_herocast,
+    title: 'Login to herocast',
+  },
+  {
+    key: OnboardingStep.connect_farcaster_account,
+    title: 'Connect Farcaster account',
+  },
+  {
+    key: OnboardingStep.create_keyword_alert,
+    title: 'Create keyword alerts and daily email',
+  },
+  {
+    key: OnboardingStep.pin_channels,
+    title: 'Pin channels',
+  },
+  {
+    key: OnboardingStep.schedule_cast,
+    title: 'Schedule casts',
+  },
+  {
+    key: OnboardingStep.done,
+    title: 'Done',
+    hide: true,
+  },
+];
+
+const WelcomeSuccessPage = () => {
+  const router = useRouter();
+  const { drafts, addNewPostDraft } = useDraftStore();
+  const [step, setStep] = useState<OnboardingStep>(OnboardingStep.create_keyword_alert);
+  const [taskStatus, setTaskStatus] = useState<OnboardingTaskStatus>({
+    [OnboardingStep.login_to_herocast]: true,
+    [OnboardingStep.connect_farcaster_account]: true,
+    [OnboardingStep.create_keyword_alert]: false,
+    [OnboardingStep.pin_channels]: false,
+    [OnboardingStep.schedule_cast]: false,
+  });
+
+  const onStartCasting = () => {
+    addNewPostDraft(JoinedHerocastPostDraft);
+    router.push('/post');
+  };
+
+  const accounts = useAccountStore((state) => state.accounts);
+  const selectedAccountIdx = useAccountStore((state) => state.selectedAccountIdx);
+  const connectedAccount = accounts[selectedAccountIdx];
+  const hasPinnedChannels = accounts && accounts.some((account) => account?.channels.length > 0);
+  const hasScheduledCasts =
+    drafts.filter((draft) => draft.status === DraftStatus.scheduled || draft.status === DraftStatus.published).length >
+    0;
+  const hasSavedSearches = useListStore((state) => state.lists.length > 0);
+
+  useEffect(() => {
+    if (hasScheduledCasts) {
+      setTaskStatus((prev) => ({ ...prev, [OnboardingStep.schedule_cast]: true }));
+    }
+  }, [hasScheduledCasts]);
+
+  useEffect(() => {
+    if (hasPinnedChannels) {
+      setTaskStatus((prev) => ({ ...prev, [OnboardingStep.pin_channels]: true }));
+    }
+  }, [hasPinnedChannels]);
+
+  useEffect(() => {
+    if (hasSavedSearches) {
+      setTaskStatus((prev) => ({ ...prev, [OnboardingStep.create_keyword_alert]: true }));
+    }
+  }, [hasSavedSearches]);
+
+  const progressPercent = (Object.values(taskStatus).filter(Boolean).length / (onboardingSteps.length - 1)) * 100;
+  const isCompleted = Object.values(taskStatus).every(Boolean);
+
+  useEffect(() => {
+    if (isCompleted) {
+      localStorage.setItem(LOCAL_STORAGE_ONBOARDING_COMPLETED_KEY, 'true');
+      // dispatch event to notify all open tabs (including the one setting it)
+      const event = new StorageEvent('storage', {
+        key: LOCAL_STORAGE_ONBOARDING_COMPLETED_KEY,
+        oldValue: undefined,
+        newValue: 'true',
+      });
+      window.dispatchEvent(event);
+    }
+  }, [isCompleted]);
+
+  const renderOnboardingSteps = () => {
+    return onboardingSteps
+      .filter((step) => !step?.hide)
+      .map((step, idx) => {
+        return (
+          <div key={step.key} className="flex items-center justify-between">
+            <div className="flex items-center align-middle">
+              <div className="flex-shrink-0 mr-2">
+                {taskStatus[step.key] ? (
+                  <CheckCircle2 className="h-6 w-6 text-success" aria-hidden="true" />
+                ) : (
+                  <Checkbox checked={false} className="cursor-default ml-0.5 mt-1 h-5 w-5 rounded-lg" />
+                )}
+              </div>
+              {step.title}
+            </div>
+          </div>
+        );
+      });
+  };
+
+  return (
+    <div className="w-full flex flex-col mt-20 items-center">
+      <div className="space-y-6 p-10 pb-16 block text-center">
+        <h2 className="text-4xl font-bold tracking-tight">welcome to herocast</h2>
+
+        {connectedAccount && (
+          <div className="max-w-2xl mx-auto space-y-4">
+            <Alert className="border-success/30 bg-success/10">
+              <AlertDescription className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <CheckCircle2 className="h-5 w-5 text-success" />
+                  <div className="flex items-center gap-3">
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage src={connectedAccount.user?.pfp_url} alt={connectedAccount.name} />
+                      <AvatarFallback>{connectedAccount.name?.slice(0, 2)}</AvatarFallback>
+                    </Avatar>
+                    <span className="text-lg font-semibold">
+                      @{connectedAccount.name || connectedAccount.user?.username} is now connected to your herocast
+                      account
+                    </span>
+                  </div>
+                </div>
+              </AlertDescription>
+            </Alert>
+
+            <div className="flex justify-center">
+              <Button
+                onClick={() => router.push(`/profile/@${connectedAccount.name || connectedAccount.user?.username}`)}
+                size="lg"
+                variant="outline"
+                className="gap-2"
+              >
+                <User className="h-4 w-4" />
+                View Profile
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div className="max-w-max mx-auto">
+          <Card className="bg-background text-foreground">
+            <CardContent className="max-w-2xl p-4">
+              <div className="flex flex-col gap-y-4 text-left">
+                {!isCompleted && (
+                  <div>
+                    <span className="text-md font-semibold">Complete these tasks to get the most out of herocast</span>
+                  </div>
+                )}
+                <div className="space-y-4 py-4 block">{renderOnboardingSteps()}</div>
+                <Progress value={progressPercent} indicatorClassName="bg-success animate-pulse" />
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-2">
+                  <Link href="/lists">
+                    <Button size="lg" type="button" variant="default" className="min-w-full px-2">
+                      <Search className="mr-1.5 mt-0.5 h-4 w-4" aria-hidden="true" />
+                      Create friends list
+                    </Button>
+                  </Link>
+                  <Link href="/channels">
+                    <Button size="lg" type="button" variant="outline" className="min-w-full px-2">
+                      <LayoutDashboard className="mr-1.5 mt-0.5 h-4 w-4" aria-hidden="true" />
+                      Pin channels
+                    </Button>
+                  </Link>
+                  <Button
+                    onClick={() => onStartCasting()}
+                    type="button"
+                    variant="outline"
+                    size="lg"
+                    className="min-w-full px-2"
+                  >
+                    <SquarePen className="mr-1.5 mt-0.5 h-4 w-4" aria-hidden="true" />
+                    Schedule casts
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WelcomeSuccessPage;

--- a/src/web/routes/_app.accounts.tsx
+++ b/src/web/routes/_app.accounts.tsx
@@ -1,0 +1,12 @@
+// Unit #9 (#754 auth/accounts) — /accounts mounted as a child of the `_app` shell (unit #5).
+// In the Next tree this is app/(app)/accounts → it gets the full app chrome (sidebar,
+// titlebar "Accounts"). Thin route: the ported page logic lives in `@/web/pages/AccountsPage`,
+// reusing the shared account-management components (QrCode, SwitchWalletButton,
+// ConfirmOnchainSignerButton, AccountManagementModal) + the wagmi/rainbowkit providers
+// (route-scoped via the unit-#3 WALLET_ROUTES) VERBATIM.
+import { createFileRoute } from '@tanstack/react-router';
+import AccountsPage from '@/web/pages/AccountsPage';
+
+export const Route = createFileRoute('/_app/accounts')({
+  component: AccountsPage,
+});

--- a/src/web/routes/_auth.tsx
+++ b/src/web/routes/_auth.tsx
@@ -1,0 +1,21 @@
+// Unit #9 (#754 auth/accounts) — pathless layout = the port of app/(auth)/layout.tsx
+// (leading `_` is TanStack's pathless convention; it adds no URL segment). Centers the
+// onboarding pages and sits OUTSIDE the `_app` shell (no app chrome — like the Next
+// `(auth)` group). The welcome routes are its children (`_auth.welcome.*.tsx`).
+//
+// `/login` is intentionally NOT under this layout — it keeps its own `routes/login.tsx`
+// (per the kickoff) and self-centers (LoginContent carries `min-h-screen`), so it renders
+// identically without the wrapper.
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_auth')({
+  component: AuthLayout,
+});
+
+function AuthLayout() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <Outlet />
+    </div>
+  );
+}

--- a/src/web/routes/_auth.welcome.connect.tsx
+++ b/src/web/routes/_auth.welcome.connect.tsx
@@ -1,0 +1,10 @@
+// Unit #9 (#754 auth/accounts) — /welcome/connect (QR + signer-poll onboarding step).
+// Thin route → `@/web/pages/WelcomeConnectPage`. Child of the `_auth` pathless layout
+// (centered, outside the app shell). A WALLET_ROUTE (unit #3) → wagmi/rainbowkit mount
+// client-only; the page never renders during SSR.
+import { createFileRoute } from '@tanstack/react-router';
+import WelcomeConnectPage from '@/web/pages/WelcomeConnectPage';
+
+export const Route = createFileRoute('/_auth/welcome/connect')({
+  component: WelcomeConnectPage,
+});

--- a/src/web/routes/_auth.welcome.new.tsx
+++ b/src/web/routes/_auth.welcome.new.tsx
@@ -1,0 +1,11 @@
+// Unit #9 (#754 auth/accounts) — /welcome/new (the create-signer onboarding entry).
+// Thin route → `@/web/pages/WelcomeNewPage`, which mounts the shared CreateAccountPage
+// CLIENT-ONLY (ssr:false) so @farcaster/hub-web's module-scope factory never runs during
+// workerd SSR (see WelcomeNewPage for the full rationale). Child of the `_auth` pathless
+// layout (centered, outside the app shell).
+import { createFileRoute } from '@tanstack/react-router';
+import WelcomeNewPage from '@/web/pages/WelcomeNewPage';
+
+export const Route = createFileRoute('/_auth/welcome/new')({
+  component: WelcomeNewPage,
+});

--- a/src/web/routes/_auth.welcome.success.tsx
+++ b/src/web/routes/_auth.welcome.success.tsx
@@ -1,0 +1,9 @@
+// Unit #9 (#754 auth/accounts) — /welcome/success (the post-connect onboarding checklist).
+// Thin route → `@/web/pages/WelcomeSuccessPage`. Child of the `_auth` pathless layout
+// (centered, outside the app shell).
+import { createFileRoute } from '@tanstack/react-router';
+import WelcomeSuccessPage from '@/web/pages/WelcomeSuccessPage';
+
+export const Route = createFileRoute('/_auth/welcome/success')({
+  component: WelcomeSuccessPage,
+});

--- a/src/web/routes/auth.auth-code-error.tsx
+++ b/src/web/routes/auth.auth-code-error.tsx
@@ -1,0 +1,10 @@
+// Unit #9 (#754 auth/accounts) — /auth/auth-code-error, the 302 callback's failure
+// redirect target. In the Next tree app/auth/auth-code-error is a standalone path (NOT in
+// the `(auth)` group), so it sits OUTSIDE both the `_app` shell and the `_auth` layout and
+// centers itself. Thin route → `@/web/pages/AuthCodeErrorPage`.
+import { createFileRoute } from '@tanstack/react-router';
+import AuthCodeErrorPage from '@/web/pages/AuthCodeErrorPage';
+
+export const Route = createFileRoute('/auth/auth-code-error')({
+  component: AuthCodeErrorPage,
+});

--- a/src/web/routes/login.tsx
+++ b/src/web/routes/login.tsx
@@ -1,34 +1,12 @@
-// PLACEHOLDER — replaced wholesale by unit #9 (auth + accounts + onboarding).
-//
-// Why it exists now (unit #5): the shared AuthContext client-redirects every logged-out
-// visitor on a shell route to `/login` (see src/common/context/AuthContext.tsx). Without
-// a matching route the canary dead-ends in the router's default not-found — this gives
-// the redirect a deterministic, honest landing page. Outside the `_app` pathless layout,
-// like app/(auth)/ in the Next tree (and `Home` early-returns children for /login).
-import { createFileRoute, Link } from '@tanstack/react-router';
+// Unit #9 (#754 auth/accounts) — the real login route, replacing the unit-#5 placeholder.
+// Outside the `_app` pathless layout (the auth tier has no app chrome, like the Next
+// `(auth)` group), so `Home`'s `/login` early-return is never even reached here — this
+// route simply doesn't mount the shell. The ported surface lives in `@/web/pages/LoginPage`
+// (the established thin-route → page pattern). The OAuth WRITE round-trip it drives runs
+// through routes/api/auth/callback.ts (the 302 callback) + supabase/server.server.ts.
+import { createFileRoute } from '@tanstack/react-router';
+import LoginPage from '@/web/pages/LoginPage';
 
 export const Route = createFileRoute('/login')({
-  component: LoginPlaceholder,
+  component: LoginPage,
 });
-
-function LoginPlaceholder() {
-  return (
-    <main className="min-h-screen flex items-center justify-center bg-background p-6">
-      <div className="max-w-md space-y-3 text-center">
-        <h1 className="text-2xl font-bold text-foreground">herocast</h1>
-        <p className="text-sm text-muted-foreground">
-          Login has not been ported to this preview yet (migration unit #9). Use the live app at{' '}
-          <a className="underline text-foreground" href="https://app.herocast.xyz/login">
-            app.herocast.xyz
-          </a>{' '}
-          to sign in.
-        </p>
-        <p className="text-sm text-muted-foreground">
-          <Link className="underline text-foreground" to="/shell-probe">
-            View the ported app shell (shell-probe)
-          </Link>
-        </p>
-      </div>
-    </main>
-  );
-}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -47,8 +47,26 @@ const ssrClientOnlyStub = fileURLToPath(new URL('./src/web/lib/ssr-client-only-s
 // - @walletconnect/ethereum-provider: dynamically imported by wagmi's walletconnect
 //   connector (wagmi is statically in the server graph via shared store/helper chains, but
 //   a wallet CONNECTION can only start in a browser — the import never runs during SSR).
+// - AccountsPage / WelcomeConnectPage (unit #9, #754 auth/accounts): the /accounts and
+//   /welcome/connect ROUTE COMPONENTS. Both render client-only (Home's `isHydrated=false`
+//   hydrate gate for /accounts; WalletProviders null-on-SSR for the /welcome/connect wallet
+//   route), so neither's body ever renders during SSR. Their import graphs pull the
+//   wagmi/rainbowkit wallet stack AND — load-bearing — @farcaster/hub-web's TEST FACTORIES
+//   (via warpcastLogin's `NobleEd25519Signer`, AccountManagement's `Change*Form → UserDataType`,
+//   and getProvider). hub-web's single-file bundle runs `Factory.build()` → `randomBytes`
+//   (@noble/hashes crypto.getRandomValues) AT MODULE SCOPE; workerd forbids that in global
+//   scope ("Disallowed operation called within global scope"). Crucially, when ONLY a lazy
+//   route (feeds) or a lazily-chunked component (CreateAccountPage) imports that factory
+//   code it stays in a lazy chunk and runs harmlessly inside a request handler (proven by
+//   #6) — but these two EAGER route components share those modules with the eager graph, so
+//   Rollup HOISTS the factory into the eager worker-entry chunk where it runs at init and
+//   EVERY route 500s. Stubbing the two page components in the ssr env keeps their whole
+//   client-only graph (wallet stack + the hub-web factory) out of the worker entirely; the
+//   throwing stub never renders server-side (both pages are gated). The client bundle keeps
+//   the real pages and code-splits as before. (This subsumes stubbing the individual wallet
+//   leaves — the buttons are only reachable via these two pages.)
 const ssrClientOnlyModules =
-  /\/(?:WalletProviders|Editor\/NewCastEditor|VideoEmbed)(?:\.tsx)?$|^@walletconnect\/ethereum-provider$/;
+  /\/(?:WalletProviders|Editor\/NewCastEditor|VideoEmbed|AccountsPage|WelcomeConnectPage)(?:\.tsx)?$|^@walletconnect\/ethereum-provider$/;
 
 // A plugin (not `environments.ssr.resolve.alias`) because the @cloudflare/vite-plugin
 // owns the `ssr` environment's config and a user-level env alias is dropped on merge
@@ -127,6 +145,12 @@ export default defineConfig(({ mode }) => {
     'process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME': inlinePublic('NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME'),
     'process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET': inlinePublic('NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET'),
     'process.env.NEXT_PUBLIC_VERCEL_ENV': inlinePublic('NEXT_PUBLIC_VERCEL_ENV'),
+    // Unit #9 (#754 auth/accounts): the wallet config (src/common/helpers/rainbowkit.tsx)
+    // builds its wagmi transports from this public Alchemy key. The host-agnostic read there
+    // prefers import.meta.env.VITE_ALCHEMY_API_KEY (inlined natively by Vite) and falls back
+    // to this — so the fallback resolves to a literal (not a `process is not defined` throw)
+    // in the browser bundle when VITE_ALCHEMY_API_KEY is unset. Public value, not a secret.
+    'process.env.NEXT_PUBLIC_ALCHEMY_API_KEY': inlinePublic('NEXT_PUBLIC_ALCHEMY_API_KEY'),
     'process.env.NEXT_PUBLIC_NEYNAR_API_KEY': 'undefined', // secret — never inline (#751)
     'process.env.NEXT_PUBLIC_APP_MNENOMIC': 'undefined', // secret — never inline
   };
@@ -145,6 +169,15 @@ export default defineConfig(({ mode }) => {
         // side-effect-free lets Rollup tree-shake the whole factory chain (incl. the
         // offending module-scope calls) out of both bundles. Everything else keeps
         // default side-effect handling.
+        //
+        // NB (unit #9, #754 auth/accounts): the SAME `Factory.build()→randomBytes` crash also
+        // lives in `@farcaster/hub-web`'s single-file bundle, but it cannot be dropped here —
+        // the factory vars are transitively REFERENCED by used hub-web exports, so
+        // `moduleSideEffects:false` does not elide them. It's instead kept OUT of the eager
+        // worker-entry chunk by stubbing the two client-only route pages that would hoist it
+        // there (AccountsPage/WelcomeConnectPage — see `ssrClientOnlyModules` above). When it
+        // lives only in lazy route/component chunks (feeds, CreateAccountPage) it runs inside
+        // a request handler, which workerd allows.
         moduleSideEffects: (id) => !id.includes('/@farcaster/core/'),
       },
     },


### PR DESCRIPTION
## Unit #9 — auth + accounts + onboarding (OAuth write)

Track B of epic #754 (Next.js → TanStack Start on Cloudflare Workers). The **critical-path surface-tier unit**: it alone unblocks #11 → #12 → #13 (cutover). Spec: `docs/migration/phase-2-auth-accounts.md`.

### What it does
Ports the real **authentication + accounts + onboarding** surfaces onto the TanStack route tree, reusing every shared component **verbatim** (C1/C3 surgical changes only — `next/navigation`→`@/web/lib/navigation`, `next/link`→`@/web/components/link`, drop `'use client'`), and wires the worker's OAuth **WRITE** through the existing phase-1 302 callback (no new auth-write path).

| Route | Source | Placement |
|-------|--------|-----------|
| `/login` | `app/(auth)/login` | replaces the unit-#5 placeholder; outside `_app` |
| `/accounts` | `app/(app)/accounts` | child of the `_app` shell |
| `/welcome/{new,connect,success}` | `app/(auth)/welcome/*` | under a faithful `_auth` pathless layout (= port of `app/(auth)/layout.tsx`) |
| `/auth/auth-code-error` | `app/auth/auth-code-error` | the 302 callback's error landing |

### The hard part — G1 (worker-init crash)
The auth/accounts routes are the **first eager, ungated importers** of `@farcaster/hub-web`'s module-scope test factory (`Factory.build()` → `@noble/hashes randomBytes`). Rollup hoisted that factory into the eager worker-entry chunk, so **every route 500'd at init** with `Disallowed operation called within global scope … generating random values` (even `/api/health`). Earlier units only reached it through SSR-gated routes (feeds hydrate gate) or lazily-chunked components, where it stays in a lazy chunk and only runs in the browser.

**Fix:** stub the two **client-only** route pages (`AccountsPage`, `WelcomeConnectPage` — both SSR-gated) in the workerd `ssr` env via `ssrClientOnlyModules`, and mount `/welcome/new`'s `CreateAccountPage` via `dynamic(ssr:false)`. This confines the factory to lazy chunks (random-gen is fine in the browser). Root-caused via bundle bisection; rationale documented in `vite.config.mts` + the spec's G1.

### The one allowed shared-file edit
`src/common/helpers/rainbowkit.tsx` ALCHEMY key made host-agnostic:
`(import.meta as any).env?.VITE_ALCHEMY_API_KEY ?? process.env.NEXT_PUBLIC_ALCHEMY_API_KEY` — Vite inlines `VITE_*` (RPC works); the `?.` keeps the Next/webpack runtime (no `import.meta.env`) from throwing; `as any` keeps the root-tsconfig typecheck green. + `define`/`​.env.local.example` entries. (Clears the strategy.md deferred item.)

### Green / verified
- `pnpm web:build` 0 · `pnpm web:typecheck` 0 · live `pnpm typecheck` 0 · `pnpm test` **150/150**
- `web:deploy:dry-run` worker bundle **2317.73 KiB gzip** (< 3 MB; +24 KiB over #6)
- **Canary (real workerd, `wrangler dev`):** `/login`, `/accounts`, `/welcome/{new,connect,success}`, `/auth/auth-code-error`, `/api/health`, `/feeds` all SSR **200 with zero `Disallowed operation` throws — both with and without secrets** (forkability bar met).
- No client-bundle secret leak (NEYNAR key name absent; secrets `define`-pinned to `undefined`).
- Tier-1 review: adversarial multi-dimension workflow (ssr-bundle / parity / conventions / correctness / auth-write), **0 confirmed findings**.

### Not verified here (needs real secrets)
The OAuth WRITE **round-trip** (login through the worker → 302 sets chunked `sb-*` cookies → `getUserFn` returns a real UUID) and **wallet RPC success** need real Supabase secrets + a configured OAuth provider + `VITE_ALCHEMY_API_KEY` at build — see the canary DoD in the spec.

### Boundaries honored
No changes to `app/`, `pages/`, `next.config.mjs`, `vercel.json`, `src/globals.css`, or any shared `src/` file except `rainbowkit.tsx`. The live Next/Vercel app is untouched.

**Do not merge** — leave for review. (Tier-2 codex integration review runs at the surface-tier boundary after #6–#9 all land.)